### PR TITLE
Clean up scheduled action comments left after migration

### DIFF
--- a/classes/ActionScheduler_wpCommentCleaner.php
+++ b/classes/ActionScheduler_wpCommentCleaner.php
@@ -74,7 +74,17 @@ class ActionScheduler_WPCommentCleaner {
 	 * Prints details about the orphaned action logs and includes information on where to learn more.
 	 */
 	public static function print_admin_notice() {
-		$notice = sprintf( __( 'Action Scheduler has completed the data migration, however, there remains scheduled action logs left in the WordPress Comments table. After 6 months, they will automatically be deleted. Click here to %slearn more%s.' ), '<a href="https://github.com/Prospress/action-scheduler">' , '</a>' );
+
+		$notice = __( 'Action Scheduler has migrated data to custom tables; however, orphaned log entries exist in the WordPress Comments table.' );
+
+		$next_scheduled_cleanup_hook = as_next_scheduled_action( self::$cleanup_hook );
+
+		if ( $next_scheduled_cleanup_hook ) {
+			$notice .= sprintf( __( ' This data will be deleted in %s.' ), human_time_diff( gmdate( 'U' ), $next_scheduled_cleanup_hook ) );
+		}
+
+		$notice .= sprintf( __( ' %sLearn more &raquo;%s' ), '<a href="https://github.com/Prospress/action-scheduler/">' , '</a>' );
+
 		echo '<div class="notice notice-warning"><p>' . wp_kses_post( $notice ) . '</p></div>';
 	}
 }

--- a/classes/ActionScheduler_wpCommentCleaner.php
+++ b/classes/ActionScheduler_wpCommentCleaner.php
@@ -27,7 +27,9 @@ class ActionScheduler_WPCommentCleaner {
 	 * Initialize the class and attach callbacks.
 	 */
 	public static function init() {
-		self::$wp_comment_logger = new ActionScheduler_wpCommentLogger();
+		if ( empty( self::$wp_comment_logger ) ) {
+			self::$wp_comment_logger = new ActionScheduler_wpCommentLogger();
+		}
 
 		add_action( self::$cleanup_hook, array( __CLASS__, 'delete_all_action_comments' ) );
 

--- a/classes/ActionScheduler_wpCommentCleaner.php
+++ b/classes/ActionScheduler_wpCommentCleaner.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Class ActionScheduler_WPCommentCleaner
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_WPCommentCleaner {
+
+	/**
+	 * Post migration hook used to cleanup the WP comment table.
+	 *
+	 * @var string
+	 */
+	protected static $cleanup_hook = 'action_scheduler/cleanup_wp_comment_logs';
+
+	/**
+	 * An instance of the ActionScheduler_wpCommentLogger class to interact with the comments table.
+	 *
+	 * This instance should only be used as an interface. It should not be initialized.
+	 *
+	 * @var ActionScheduler_wpCommentLogger
+	 */
+	protected static $wp_comment_logger = null;
+
+	/**
+	 * Initialize the class and attach callbacks.
+	 */
+	public static function init() {
+		self::$wp_comment_logger = new ActionScheduler_wpCommentLogger();
+
+		add_action( self::$cleanup_hook, array( __CLASS__, 'delete_all_action_comments' ) );
+
+		// While there are orphaned logs left in the comments table, we need to attach the callbacks which filter comment counts.
+		add_action( 'pre_get_comments', array( self::$wp_comment_logger, 'filter_comment_queries' ), 10, 1 );
+		add_action( 'wp_count_comments', array( self::$wp_comment_logger, 'filter_comment_count' ), 20, 2 ); // run after WC_Comments::wp_count_comments() to make sure we exclude order notes and action logs
+		add_action( 'comment_feed_where', array( self::$wp_comment_logger, 'filter_comment_feed' ), 10, 2 );
+
+		// Action Scheduler may be displayed as a Tools screen or WooCommerce > Status administration screen
+		add_action( 'load-tools_page_action-scheduler', array( __CLASS__, 'print_admin_notice' ) );
+		add_action( 'load-woocommerce_page_wc-status', array( __CLASS__, 'print_admin_notice' ) );
+	}
+
+	/**
+	 * Determines if there are log entries in the wp comments table.
+	 *
+	 * @return boolean Whether there are scheduled action comments in the comments table.
+	 */
+	public static function has_logs() {
+		return (bool) get_comments( array( 'type' => ActionScheduler_wpCommentLogger::TYPE, 'number' => 1, 'fields' => 'ids' ) );
+	}
+
+	/**
+	 * Schedules the WP Post comment table cleanup to run in 6 months if it's not already scheduled.
+	 * Attached to the migration complete hook 'action_scheduler/migration_complete'.
+	 */
+	public static function maybe_schedule_cleanup() {
+		if ( ! as_next_scheduled_action( self::$cleanup_hook ) && self::has_logs() ) {
+			as_schedule_single_action( gmdate( U ) + ( 6 * MONTH_IN_SECONDS ), self::$cleanup_hook );
+		}
+	}
+
+	/**
+	 * Delete all action comments from the WP Comments table.
+	 */
+	public static function delete_all_action_comments() {
+		global $wpdb;
+		$wpdb->delete( $wpdb->comments, array( 'comment_type' => ActionScheduler_wpCommentLogger::TYPE, 'comment_agent' => ActionScheduler_wpCommentLogger::AGENT ) );
+	}
+
+	/**
+	 * Prints details about the orphaned action logs and includes information on where to learn more.
+	 */
+	public static function print_admin_notice() {
+		$notice = sprintf( __( 'Action Scheduler has completed the data migration, however, there remains scheduled action logs left in the WordPress Comments table. After 6 months, they will automatically be deleted. Click here to %slearn more%s.' ), '<a href="https://github.com/Prospress/action-scheduler">' , '</a>' );
+		echo '<div class="notice notice-warning"><p>' . wp_kses_post( $notice ) . '</p></div>';
+	}
+}

--- a/classes/ActionScheduler_wpCommentCleaner.php
+++ b/classes/ActionScheduler_wpCommentCleaner.php
@@ -83,7 +83,7 @@ class ActionScheduler_WPCommentCleaner {
 			$notice .= sprintf( __( ' This data will be deleted in %s.' ), human_time_diff( gmdate( 'U' ), $next_scheduled_cleanup_hook ) );
 		}
 
-		$notice .= sprintf( __( ' %sLearn more &raquo;%s' ), '<a href="https://github.com/Prospress/action-scheduler/">' , '</a>' );
+		$notice .= sprintf( __( ' %sLearn more &raquo;%s' ), '<a href="https://github.com/Prospress/action-scheduler/issues/368">' , '</a>' );
 
 		echo '<div class="notice notice-warning"><p>' . wp_kses_post( $notice ) . '</p></div>';
 	}

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -164,7 +164,7 @@ abstract class ActionScheduler {
 		/**
 		 * Handle WP comment cleanup after migration.
 		 */
-		if ( ! is_a( $logger, 'ActionScheduler_wpCommentLogger' ) && ActionScheduler_DataController::is_migration_complete() && ActionScheduler_WPCommentCleaner::has_logs() ) {
+		if ( is_a( $logger, 'ActionScheduler_DBLogger' ) && ActionScheduler_DataController::is_migration_complete() && ActionScheduler_WPCommentCleaner::has_logs() ) {
 			ActionScheduler_WPCommentCleaner::init();
 		}
 

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -160,6 +160,15 @@ abstract class ActionScheduler {
 				$command->register();
 			}
 		}
+
+		/**
+		 * Handle WP comment cleanup after migration.
+		 */
+		if ( ! is_a( $logger, 'ActionScheduler_wpCommentLogger' ) && ActionScheduler_DataController::is_migration_complete() && ActionScheduler_WPCommentCleaner::has_logs() ) {
+			ActionScheduler_WPCommentCleaner::init();
+		}
+
+		add_action( 'action_scheduler/migration_complete', 'ActionScheduler_WPCommentCleaner::maybe_schedule_cleanup' );
 	}
 
 	/**


### PR DESCRIPTION
### Description
This PR introduces a `ActionScheduler_WPCommentCleaner` to handle scheduled action comments left in the comments table after migration is complete. 

See #368 for more details.

### To test

1. Start with a site pre-migration. 
1. Manually delete 10 or so scheduled actions manually from the database. See 1st example query below. 
1. Upgrade to AS 3.0 and let the migration finish.
1. Once the migration is complete go to the **Scheduled Actions** screen.
1. At the top, you should see [this admin notice](https://user-images.githubusercontent.com/8490476/66460784-f8c53080-eaba-11e9-8b12-3431ebb4c0af.png).
1. Search your database for orphaned action log comments. See 2nd query below. Make a note of how many comments are left behind. ([screenshot](https://user-images.githubusercontent.com/8490476/66459481-6a4faf80-eab8-11e9-9937-554cb3d64f48.png))
1. Now search your scheduled actions for the hook `'action_scheduler/cleanup_wp_comment_logs'`.
1. [You should get 1 result scheduled to run in 6 months.](https://cld.wthms.co/vZtY3F)
1. Manually run that action and confirm the orphaned action log comments have been deleted. ([screenshot](https://user-images.githubusercontent.com/8490476/66459489-6d4aa000-eab8-11e9-95c1-5d1da616c6cc.png))

```mysql
DELETE FROM wp_posts WHERE post_type = 'scheduled-action' LIMIT 10
```

```mysql
SELECT * FROM wp_comments WHERE comment_type = 'action_log';
```

I've also tested on the site with 139k action comments left after migration and the extremely slow page load times has also been fixed. Let me know if you'd like steps on how to test this.

### Notes

I've left the notice linking to the main repo https://github.com/Prospress/action-scheduler/. We need to write a wiki page or similar and update it before this is merged. I've submitted this to get feedback on the way I've implemented it and the content of the notice. 



