### PR TITLE
Initialise on load instead of 'plugins_loaded' when loaded after 'plugins_loaded'

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -29,10 +29,10 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_0_dot_0_beta_1' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
-		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
+		add_action( 'init', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), -10, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_0_dot_0_beta_1', 0, 0 );
+	add_action( 'init', 'action_scheduler_register_3_dot_0_dot_0_beta_1', -20, 0 );
 
 	function action_scheduler_register_3_dot_0_dot_0_beta_1() {
 		$versions = ActionScheduler_Versions::instance();

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -44,4 +44,10 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_0_dot_0_beta_1' ) ) {
 		ActionScheduler::init( __FILE__ );
 	}
 
+	// Support usage in themes - load this version if no plugin has loaded a version yet.
+	if ( did_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
+		action_scheduler_register_3_dot_0_dot_0_beta_1();
+		do_action( 'action_scheduler_pre_theme_init' );
+		ActionScheduler_Versions::initialize_latest_version();
+	}
 }

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -29,10 +29,10 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_0_dot_0_beta_1' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
-		add_action( 'init', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), -10, 0 );
+		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'init', 'action_scheduler_register_3_dot_0_dot_0_beta_1', -20, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_0_dot_0_beta_1', 0, 0 );
 
 	function action_scheduler_register_3_dot_0_dot_0_beta_1() {
 		$versions = ActionScheduler_Versions::instance();

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ### Is it safe to release Action Scheduler in my plugin? Won't its functions conflict with another copy of the library?
 
-Action Scheduler is designed to be used and released in plugins. It avoids redeclaring public API functions when more than one copy of the library is being loaded by different plugins. It will also load only the most recent version of itself (by checking registered versions after all plugins are loaded on the `'plugins_loaded'` hook).
+Action Scheduler is designed to be used and released in plugins. It avoids redeclaring public API functions when more than one copy of the library is being loaded by different plugins. It will also load only the most recent version of itself (by checking registered versions after all plugins are loaded on the `'init'` hook with priority `-10`).
 
 To use it in your plugin, simply require the `action-scheduler/action-scheduler.php` file. Action Scheduler will take care of the rest.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ### Is it safe to release Action Scheduler in my plugin? Won't its functions conflict with another copy of the library?
 
-Action Scheduler is designed to be used and released in plugins. It avoids redeclaring public API functions when more than one copy of the library is being loaded by different plugins. It will also load only the most recent version of itself (by checking registered versions after all plugins are loaded on the `'init'` hook with priority `-10`).
+Action Scheduler is designed to be used and released in plugins. It avoids redeclaring public API functions when more than one copy of the library is being loaded by different plugins. It will also load only the most recent version of itself (by checking registered versions after all plugins are loaded on the `'plugins_loaded'` hook).
 
 To use it in your plugin, simply require the `action-scheduler/action-scheduler.php` file. Action Scheduler will take care of the rest.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,3 +121,7 @@ Action Scheduler will register its version on `'plugins_loaded'` with priority `
 It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'plugins_loaded'`, or you can use `'plugins_loaded'` with negative priority, like `-10`.
 
 Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`.
+
+### Usage in Themes
+
+When using Action Scheduler in themes, it's important to note that if Action Scheduler has been registered by a plugin, then the latest version registered by a plugin will be used, rather than the version included in the theme. This is because of the version dependency handling code using `'plugins_loaded'` since version 1.0.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,8 +116,8 @@ When the `action-scheduler.php` file is included, Action Scheduler will register
 
 ### Load Order
 
-Action Scheduler will register its version on `'init'` with priority `-20` - after all other plugin and theme codebases has been loaded. Therefore **the `action-scheduler.php` file must be included before `'init'` priority `-20`**.
+Action Scheduler will register its version on `'plugins_loaded'` with priority `0` - after all other plugin codebases has been loaded. Therefore **the `action-scheduler.php` file must be included before `'plugins_loaded'` priority `0`**.
 
-It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'init'`, or you can use `'init'` with negative priority greater than `-20`, like `-100`.
+It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'plugins_loaded'`, or you can use `'plugins_loaded'` with negative priority, like `-10`.
 
-Action Scheduler will later initialize itself on `'init'` with priority `-10`.  Action Scheduler APIs should not be used until after `'init'` with priority `-10`.
+Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,8 +116,8 @@ When the `action-scheduler.php` file is included, Action Scheduler will register
 
 ### Load Order
 
-Action Scheduler will register its version on `'plugins_loaded'` with priority `0` - after all other plugin codebases has been loaded. Therefore **the `action-scheduler.php` file must be included before `'plugins_loaded'` priority `0`**.
+Action Scheduler will register its version on `'init'` with priority `-20` - after all other plugin and theme codebases has been loaded. Therefore **the `action-scheduler.php` file must be included before `'init'` priority `-20`**.
 
-It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'plugins_loaded'`, or you can use `'plugins_loaded'` with negative priority, like `-10`.
+It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'init'`, or you can use `'init'` with negative priority greater than `-20`, like `-100`.
 
-Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`.
+Action Scheduler will later initialize itself on `'init'` with priority `-10`.  Action Scheduler APIs should not be used until after `'init'` with priority `-10`.


### PR DESCRIPTION
To fix usage within themes, which are loaded after 'plugins_loaded'.

This is a potentially dangerous breaking change, because 3rd party code may have expected Action Scheduler to be initialized on `'plugins_loaded'` with priority > `1`. There's no way to support use in themes, and fix #359, without introducing that change. If we see issues arise during the RC period, or even after public release of 3.0.0, I propose we revert this change and document that theme usage is not supported (at least, not without some other code).

Fixes #359.

---

I've also updated the doc on **Load Order** to reflect these changes. That doc appears to have been incorrect previously, stating:

> Action Scheduler will later initialize itself on `'init'` with priority `1`

When really, Action Scheduler was initialized on `'plugins_loaded'` with priority `1`. I checked the Git history, and can't see any history of Action Scheduler initializing itself on `'init'` even [before version 1.0.0](https://github.com/woocommerce/action-scheduler/commit/2af908e1a6727846a8d11e92ab5f135c4080e120#diff-4f18dbf952a597f7ef96664aaa47df23), so I think this must have been a mistake.