### PR TITLE
Support updating from custom tables plugin schema

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -64,6 +64,25 @@ abstract class ActionScheduler_Abstract_Schema {
 		$option_name         = 'schema-' . static::class;
 		$version_found_in_db = get_option( $option_name, 0 );
 
+		// Check for schema option stored by the Action Scheduler Custom Tables plugin in case site has migrated from that plugin with an older schema
+		if ( 0 === $version_found_in_db ) {
+
+			$plugin_option_name = 'schema-';
+
+			switch ( static::class ) {
+				case 'ActionScheduler_StoreSchema' :
+					$plugin_option_name .= 'Action_Scheduler\Custom_Tables\DB_Store_Table_Maker';
+					break;
+				case 'ActionScheduler_LoggerSchema' :
+					$plugin_option_name .= 'Action_Scheduler\Custom_Tables\DB_Logger_Table_Maker';
+					break;
+			}
+
+			$version_found_in_db = get_option( $plugin_option_name, 0 );
+
+			delete_option( $plugin_option_name );
+		}
+
 		return version_compare( $version_found_in_db, $this->schema_version, '<' );
 	}
 


### PR DESCRIPTION
If no schema value is found (i.e. `0 === $version_found_in_db`), this patch will fallback to check for a schema value set by the Custom Tables plugin. If none is set, or the original schema is set, then `$version_found_in_db` will still be `0`, and the schema update will run; however, the old schema option will be deleted.

One change this patch introduces - if the latest schema from the Custom Tables plugin is set, schema `1`, then no schema update will run. I believe there have been no schema changes in adding the custom tables code to Action Scheduler core, so no schema update would be required, is that correct @rrennick?

If there has, then we should also make the schema used in AS core `2`.

Fixes #367