### PR TITLE
Update Prospress references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Action Scheduler - Job Queue for WordPress [![Build Status](https://travis-ci.org/Prospress/action-scheduler.png?branch=master)](https://travis-ci.org/Prospress/action-scheduler) [![codecov](https://codecov.io/gh/Prospress/action-scheduler/branch/master/graph/badge.svg)](https://codecov.io/gh/Prospress/action-scheduler)
+# Action Scheduler - Job Queue for WordPress [![Build Status](https://travis-ci.org/woocommerce/action-scheduler.png?branch=master)](https://travis-ci.org/woocommerce/action-scheduler) [![codecov](https://codecov.io/gh/woocommerce/action-scheduler/branch/master/graph/badge.svg)](https://codecov.io/gh/woocommerce/action-scheduler)
 
 Action Scheduler is a scalable, traceable job queue for background processing large sets of actions in WordPress. It's specially designed to be distributed in WordPress plugins.
 
@@ -30,12 +30,6 @@ There you will find:
 
 ## Credits
 
-Action Scheduler is developed and maintained by [Prospress](http://prospress.com/) in collaboration with [Flightless](https://flightless.us/).
+Action Scheduler is developed and maintained by [Automattic](http://automattic.com/) with significant early development completed by [Flightless](https://flightless.us/).
 
-Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/prospress/action-scheduler/pulls) welcome.
-
----
-
-<p align="center">
-<img src="https://cloud.githubusercontent.com/assets/235523/11986380/bb6a0958-a983-11e5-8e9b-b9781d37c64a.png" width="160">
-</p>
+Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/woocommerce/action-scheduler/pulls) welcome.

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -3,12 +3,10 @@
  * Plugin Name: Action Scheduler
  * Plugin URI: https://actionscheduler.org
  * Description: A robust scheduling library for use in WordPress plugins.
- * Author: Prospress
- * Author URI: https://prospress.com/
+ * Author: Automattic
+ * Author URI: https://automattic.com/
  * Version: 3.0.0-RC-1
  * License: GPLv3
- *
- * Copyright 2019 Prospress, Inc.  (email : freedoms@prospress.com)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/classes/ActionScheduler_Exception.php
+++ b/classes/ActionScheduler_Exception.php
@@ -5,7 +5,7 @@
  *
  * Facilitates catching Exceptions unique to Action Scheduler.
  *
- * @package Prospress\ActionScheduler
+ * @package ActionScheduler
  * @since %VERSION%
  */
 interface ActionScheduler_Exception {}

--- a/classes/ActionScheduler_InvalidActionException.php
+++ b/classes/ActionScheduler_InvalidActionException.php
@@ -5,7 +5,7 @@
  *
  * Used for identifying actions that are invalid in some way.
  *
- * @package Prospress\ActionScheduler
+ * @package ActionScheduler
  */
 class ActionScheduler_InvalidActionException extends \InvalidArgumentException implements ActionScheduler_Exception {
 

--- a/classes/ActionScheduler_wpCommentCleaner.php
+++ b/classes/ActionScheduler_wpCommentCleaner.php
@@ -97,7 +97,7 @@ class ActionScheduler_WPCommentCleaner {
 			$notice .= sprintf( __( ' This data will be deleted in %s.' ), human_time_diff( gmdate( 'U' ), $next_scheduled_cleanup_hook ) );
 		}
 
-		$notice .= sprintf( __( ' %sLearn more &raquo;%s' ), '<a href="https://github.com/Prospress/action-scheduler/issues/368">' , '</a>' );
+		$notice .= sprintf( __( ' %sLearn more &raquo;%s' ), '<a href="https://github.com/woocommerce/action-scheduler/issues/368">' , '</a>' );
 
 		echo '<div class="notice notice-warning"><p>' . wp_kses_post( $notice ) . '</p></div>';
 	}

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Commands for the Action Scheduler by Prospress.
+ * Commands for Action Scheduler.
  */
 class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 

--- a/classes/WP_CLI/ProgressBar.php
+++ b/classes/WP_CLI/ProgressBar.php
@@ -3,7 +3,7 @@
 namespace Action_Scheduler\WP_CLI;
 
 /**
- * WP_CLI progress bar for the Action Scheduler by Prospress.
+ * WP_CLI progress bar for Action Scheduler.
  */
 
 /**

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -94,7 +94,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	 * action's slug, being probably unique is good enough.
 	 *
 	 * For more backstory on this issue, see:
-	 * - https://github.com/Prospress/action-scheduler/issues/44 and
+	 * - https://github.com/woocommerce/action-scheduler/issues/44 and
 	 * - https://core.trac.wordpress.org/ticket/21112
 	 *
 	 * @param string $override_slug Short-circuit return value.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,7 +21,7 @@
   <body>
 
     <header>
-      <a class="github-corner" href="https://github.com/Prospress/action-scheduler/" aria-label="View on GitHub">
+      <a class="github-corner" href="https://github.com/woocommerce/action-scheduler/" aria-label="View on GitHub">
         <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#b5e853; color:#151513; position: fixed; top: 0; border: 0; right: 0;" aria-hidden="true">
           <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
         </svg>
@@ -42,9 +42,6 @@
     <footer>
         <div class="container">
             <p><a href="/usage/">Usage</a> | <a href="/admin/">Admin</a> | <a href="/wp-cli/">WP-CLI</a> | <a href="/perf/">Background Processing at Scale</a> | <a href="/api/">API</a> | <a href="/faq/">FAQ</a>
-            <p class="footer-image">
-                <a href="https://prospress.com"><img src="http://pic.pros.pr/eb8dcec9bd54/prospress-hacker-green-logo.png" width="120"></a>
-            </p>
         </div>
     </footer>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,9 +22,9 @@ Or trigger the `'action_scheduler_run_queue'` hook and let Action Scheduler do i
 do_action( 'action_scheduler_run_queue', $context_identifier );
 ```
 
-Further customization can be done by extending the `ActionScheduler_Abstract_QueueRunner` class to create a custom Queue Runner. For an example of a customized queue runner, see the [`ActionScheduler_WPCLI_QueueRunner`](https://github.com/Prospress/action-scheduler/blob/master/classes/ActionScheduler_WPCLI_QueueRunner.php), which is used when running WP CLI.
+Further customization can be done by extending the `ActionScheduler_Abstract_QueueRunner` class to create a custom Queue Runner. For an example of a customized queue runner, see the [`ActionScheduler_WPCLI_QueueRunner`](https://github.com/woocommerce/action-scheduler/blob/master/classes/ActionScheduler_WPCLI_QueueRunner.php), which is used when running WP CLI.
 
-Want to create some other method for initiating Action Scheduler? [Open a new issue](https://github.com/Prospress/action-scheduler/issues/new), we'd love to help you with it.
+Want to create some other method for initiating Action Scheduler? [Open a new issue](https://github.com/woocommerce/action-scheduler/issues/new), we'd love to help you with it.
 
 ### I don't want to use WP-Cron, ever. Does Action Scheduler replace WP-Cron?
 
@@ -36,7 +36,7 @@ You could use the `'schedule_event'` hook in WordPress to use Action Scheduler f
 
 Alternatively, you can use a combination of the `'pre_update_option_cron'` and  `'pre_option_cron'` hooks to override all new and previously scheduled WP-Cron jobs (similar to the way [Cavalcade](https://github.com/humanmade/Cavalcade) does it).
 
-If you'd like to create a plugin to do this automatically and want to share your work with others, [open a new issue to let us know](https://github.com/Prospress/action-scheduler/issues/new), we'd love to help you with it.
+If you'd like to create a plugin to do this automatically and want to share your work with others, [open a new issue to let us know](https://github.com/woocommerce/action-scheduler/issues/new), we'd love to help you with it.
 
 ### Eww gross, Custom Post Types! That's _so_ 2010. Can I use a different storage scheme?
 
@@ -58,9 +58,9 @@ add_filter( 'action_scheduler_store_class', 'eg_define_custom_store', 10, 1 );
 
 Take a look at the `ActionScheduler_wpPostStore` class for an example implementation of `ActionScheduler_Store`.
 
-If you'd like to create a plugin to do this automatically and release it publicly to help others, [open a new issue to let us know](https://github.com/Prospress/action-scheduler/issues/new), we'd love to help you with it.
+If you'd like to create a plugin to do this automatically and release it publicly to help others, [open a new issue to let us know](https://github.com/woocommerce/action-scheduler/issues/new), we'd love to help you with it.
 
-> Note: we're also moving Action Scheduler itself to use [custom tables for better scalability](https://github.com/Prospress/action-scheduler/issues/77).
+> Note: we're also moving Action Scheduler itself to use [custom tables for better scalability](https://github.com/woocommerce/action-scheduler/issues/77).
 
 ### Can I use a different storage scheme just for logging?
 
@@ -98,4 +98,4 @@ It requires no setup, and won't override any WordPress APIs (unless you want it 
 
 Action Scheduler is designed to manage the scheduled actions on a single site. It has no special handling for running queues across multiple sites in a multisite network. That said, because its storage and Queue Runner are completely swappable, it would be possible to write multisite handling classes to use with it.
 
-If you'd like to create a multisite plugin to do this and release it publicly to help others, [open a new issue to let us know](https://github.com/Prospress/action-scheduler/issues/new), we'd love to help you with it.
+If you'd like to create a multisite plugin to do this and release it publicly to help others, [open a new issue to let us know](https://github.com/woocommerce/action-scheduler/issues/new), we'd love to help you with it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,6 @@ Actions can also be grouped together using a custom taxonomy named `action-group
 
 ## Credits
 
-Developed and maintained by [Prospress](http://prospress.com/) in collaboration with [Flightless](https://flightless.us/).
+Action Scheduler is developed and maintained by [Automattic](http://automattic.com/) with significant early development completed by [Flightless](https://flightless.us/).
 
-Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/prospress/action-scheduler/pulls) welcome.
+Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/woocommerce/action-scheduler/pulls) welcome.

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -124,4 +124,4 @@ add_action( 'wp_ajax_nopriv_eg_create_additional_runners', 'eg_create_additional
 
 ## High Volume Plugin
 
-It's not necessary to add all of this code yourself, the folks at [Prospress](https://prospress.com) have created a handy plugin to get access to each of these increases -  the [Action Scheduler - High Volume](https://github.com/prospress/action-scheduler-high-volume) plugin.
+It's not necessary to add all of this code yourself, there is a handy plugin to get access to each of these increases -  the [Action Scheduler - High Volume](https://github.com/woocommerce/action-scheduler-high-volume) plugin.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,7 +53,7 @@ Action Scheduler includes the necessary file headers to be used as a standard Wo
 
 To install it as a plugin:
 
-1. Download the .zip archive of the latest [stable release](https://github.com/Prospress/action-scheduler/releases)
+1. Download the .zip archive of the latest [stable release](https://github.com/woocommerce/action-scheduler/releases)
 1. Go to the **Plugins > Add New > Upload** administration screen on your WordPress site
 1. Select the archive file you just downloaded
 1. Click **Install Now**
@@ -77,7 +77,7 @@ To include Action Scheduler as a git subtree:
 #### Step 1. Add the Repository as a Remote
 
 ```
-git remote add -f subtree-action-scheduler https://github.com/Prospress/action-scheduler.git
+git remote add -f subtree-action-scheduler https://github.com/woocommerce/action-scheduler.git
 ```
 
 Adding the subtree as a remote allows us to refer to it in short from via the name `subtree-action-scheduler`, instead of the full GitHub URL.
@@ -112,7 +112,7 @@ require_once( plugin_dir_path( __FILE__ ) . '/libraries/action-scheduler/action-
 
 There is no need to call any functions or do else to initialize Action Scheduler.
 
-When the `action-scheduler.php` file is included, Action Scheduler will register the version in that file and then load the most recent version of itself on the site. It will also load the most recent version of [all API functions](https://github.com/prospress/action-scheduler#api-functions).
+When the `action-scheduler.php` file is included, Action Scheduler will register the version in that file and then load the most recent version of itself on the site. It will also load the most recent version of [all API functions](https://actionscheduler.org/api/).
 
 ### Load Order
 

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -13,7 +13,7 @@ For large sites, WP CLI is a much better choice for running queues of actions th
 
 With a regular web request, you may have to deal with script timeouts enforced by hosts, or other restraints that make it more challenging to run Action Scheduler tasks. Utilizing WP CLI to run commands directly on the server give you more freedom. This means that you typically don't have the same constraints of a normal web request.
 
-If you choose to utilize WP CLI exclusively, you can disable the normal WP CLI queue runner by installing the [Action Scheduler - Disable Default Queue Runner](https://github.com/Prospress/action-scheduler-disable-default-runner) plugin. Note that if you do this, you **must** run Action Scheduler via WP CLI or another method, otherwise no scheduled actions will be processed.
+If you choose to utilize WP CLI exclusively, you can disable the normal WP CLI queue runner by installing the [Action Scheduler - Disable Default Queue Runner](https://github.com/woocommerce/action-scheduler-disable-default-runner) plugin. Note that if you do this, you **must** run Action Scheduler via WP CLI or another method, otherwise no scheduled actions will be processed.
  
 ## Commands
 


### PR DESCRIPTION
To refer to the current `/woocommerce/` repo on GitHub, or Automattic, as required.