### PR TITLE
Fix error reporting use of undeclared constant U meant to be 'U'

### DIFF
--- a/classes/ActionScheduler_wpCommentCleaner.php
+++ b/classes/ActionScheduler_wpCommentCleaner.php
@@ -70,7 +70,7 @@ class ActionScheduler_WPCommentCleaner {
 			update_option( self::$has_logs_option_key, 'yes' );
 
 			if ( ! as_next_scheduled_action( self::$cleanup_hook ) ) {
-				as_schedule_single_action( gmdate( U ) + ( 6 * MONTH_IN_SECONDS ), self::$cleanup_hook );
+				as_schedule_single_action( gmdate( 'U' ) + ( 6 * MONTH_IN_SECONDS ), self::$cleanup_hook );
 			}
 		}
 	}


### PR DESCRIPTION
Noticed while looking through my error log:

```
PHP Warning:  Use of undefined constant U - assumed 'U' (this will throw an Error in a future version of PHP) in /app/public/wp-content/plugins/action-scheduler/classes/ActionScheduler_WPCommentCleaner.php on line 61
```