### PR TITLE
Fixed docblock about ActionScheduler_Abstract_ListTable::$package

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -29,7 +29,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	protected $table_name;
 
 	/**
-	 * Package name, used in translations
+	 * Package name, used to get options from WP_List_Table::get_items_per_page.
 	 */
 	protected $package;
 


### PR DESCRIPTION
Just a small tweak in the docblock, I missed it in my previous PR.