### PR TITLE
restrict class autoloader to AS namespaces on namespaced classes

### DIFF
--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -95,7 +95,7 @@ class ActionScheduler_DataController {
 	}
 
 	/**
-	 * Set the tick count reuired for freeing memory.
+	 * Set the tick count required for freeing memory.
 	 *
 	 * @param integer $free_ticks The number of ticks to free memory on.
 	 */

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -69,6 +69,9 @@ abstract class ActionScheduler {
 		$classes_dir = self::plugin_path( 'classes' . $d );
 		$separator   = strrpos( $class, '\\' );
 		if ( false !== $separator ) {
+			if ( 0 !== strpos( $class, 'Action_Scheduler' ) ) {
+				return;
+			}
 			$class = substr( $class, $separator + 1 );
 		}
 


### PR DESCRIPTION
Closes #385 

PHP calls autoloader functions in the order they are registered. WordPress loads plugins in alphabetical order so AS is one of the first plugins loaded. The AS autoloader function did not check to see if a requested namespaced class was under the `Action_Scheduler` namespace. This PR adds that check and fixes a PHPDoc comment typo.