### PR TITLE
Prevent Uncaught Exception: Invalid post status. No matching action status available.

### DIFF
--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -43,16 +43,16 @@ class ActionMigrator {
 	 * @return int 0|new action ID
 	 */
 	public function migrate( $source_action_id ) {
-		$action = $this->source->fetch_action( $source_action_id );
-
 		try {
+			$action = $this->source->fetch_action( $source_action_id );
 			$status = $this->source->get_status( $source_action_id );
 		} catch ( \Exception $e ) {
+			$action = null;
 			$status = '';
 		}
 
-		if ( empty( $status ) || ! $action->get_schedule()->get_date() ) {
-			// empty status means the action didn't exist
+		if ( ! $action instanceof \ActionScheduler_Action || empty( $status ) || ! $action->get_schedule()->get_date() ) {
+			// null action or empty status means the fetch operation failed or the action didn't exist
 			// null schedule means it's missing vital data
 			// delete it and move on
 			try {

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -51,7 +51,7 @@ class ActionMigrator {
 			$status = '';
 		}
 
-		if ( ! $action instanceof \ActionScheduler_Action || empty( $status ) || ! $action->get_schedule()->get_date() ) {
+		if ( is_null( $action ) || empty( $status ) || ! $action->get_schedule()->get_date() ) {
 			// null action or empty status means the fetch operation failed or the action didn't exist
 			// null schedule means it's missing vital data
 			// delete it and move on


### PR DESCRIPTION
This PR aims to prevent `Uncaught Exception: Invalid post status: "{status}". No matching action status available.` while trying to migrate scheduled actions that somehow have ended up with a custom value in the `post_status` column.

One of the queries that `BatchFetcher` attempts allows scheduled actions with custom post status to be retrieved:

https://github.com/woocommerce/action-scheduler/blob/535a718e94b16794de56070e415e76d0898f8afc/classes/migration/BatchFetcher.php#L66-L73

However, trying to convert a post that represents one of those actions into an `ActionScheduler_Action` always fails with an `InvalidArgumentException` exception:

https://github.com/woocommerce/action-scheduler/blob/535a718e94b16794de56070e415e76d0898f8afc/classes/data-stores/ActionScheduler_wpPostStore.php#L184-L186

I found about this scenario after seeing a scheduled action post with `post_status` set to `wc-active` (have no idea why or how) on a customer's website. That single post is preventing the migration in Action Scheduler 3.0 RC3 from completing on that site and is causing the actions table to be filled with `action_scheduler/migration_hook` actions that come and go but are unable to migrate all the records.

At first I wasn't sure what to do with tasks that have custom/invalid status, but as I was writing this description for an issue, I remembered seeing these lines:

https://github.com/woocommerce/action-scheduler/blob/535a718e94b16794de56070e415e76d0898f8afc/classes/migration/ActionMigrator.php#L46-L59

I think "delete them" is a good answer, and in that case, I would like to propose to catch the `InvalidArgumentException` exception when the action is created and attempt to delete the record from the source data store if the fetch operation fails.