### PR TITLE
Check for in-progress / running actions as next action

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -129,22 +129,36 @@ function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
 }
 
 /**
+ * Check if there is an existing action in the queue with a given hook, args and group combination.
+ *
+ * An action in the queue could be pending, in-progress or aysnc. If the is pending for a time in
+ * future, its scheduled date will be returned as a timestamp. If it is currently being run, or an
+ * async action sitting in the queue waiting to be processed, in which case boolean true will be
+ * returned. Or there may be no async, in-progress or pending action for this hook, in which case,
+ * boolean false will be the return value.
+ *
  * @param string $hook
  * @param array $args
  * @param string $group
  *
- * @return int|bool The timestamp for the next occurrence of a scheduled action, true for an async action or false if there is no matching, pending action.
+ * @return int|bool The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
  */
 function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
-	$params = array(
-		'status' => ActionScheduler_Store::STATUS_PENDING,
-	);
+	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
 	}
 	if ( !empty($group) ) {
 		$params['group'] = $group;
 	}
+
+	$params['status'] = ActionScheduler_Store::STATUS_RUNNING;
+	$job_id = ActionScheduler::store()->find_action( $hook, $params );
+	if ( ! empty( $job_id ) ) {
+		return true;
+	}
+
+	$params['status'] = ActionScheduler_Store::STATUS_PENDING;
 	$job_id = ActionScheduler::store()->find_action( $hook, $params );
 	if ( empty($job_id) ) {
 		return false;


### PR DESCRIPTION
To avoid scheduling duplicates of long running actions when the action is being scheduled on a hook like 'init'.

For more background on why this implementation was chosen, see https://github.com/woocommerce/action-scheduler/issues/387#issuecomment-553222804

Fixes #387.

Fixes #386.

### Testing

To test the bug with 3.0 or 2.n:

1. Add the snippet below to a plugin or theme's `functions.php`
1. Go to **Tools > Scheduled Actions** admin screen
1. Search actions for `as_test_duplicate`
1. Click _Run_ on the pending `as_test_duplicate` action
1. Observe that there is both an `in-progress`, and `pending` action
1. Wait about 15 seconds
1. Observe that that there are two `pending` actions
1. Checkout `issue_387` branch
1. Delete one of the pending actions
1. Repeat steps 2, 3 & 4
1. Observe that no duplicate is ever added

Test snippet:

```
function as_test_duplicate_schedule() {
	if ( false === as_next_scheduled_action( 'as_test_duplicate' ) ) {
		as_schedule_recurring_action( time() + MINUTE_IN_SECONDS, MINUTE_IN_SECONDS, 'as_test_duplicate' );
	}
}
add_action( 'init', 'as_test_duplicate_schedule' );

function as_test_duplicate_sleep() {
	sleep(15);
}
add_action( 'as_test_duplicate', 'as_test_duplicate_sleep' );
```