### PR TITLE
mark action as migrated if delete fails

### DIFF
--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -304,7 +304,15 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 		return ! empty( $pending_actions );
 	}
 
+	/**
+	 * Callable initialization function optionally overridden in derived classes.
+	 */
 	public function init() {}
+
+	/**
+	 * Callable function to mark an action as migrated optionally overridden in derived classes.
+	 */
+	public function mark_migrated( $action_id ) {}
 
 	/**
 	 * @return ActionScheduler_Store

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -12,9 +12,6 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	protected $local_timezone = NULL;
 
 	/** @var int */
-	protected $last_deleted_action = null;
-
-	/** @var int */
 	private static $max_index_length = 191;
 
 	public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ){
@@ -474,14 +471,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 		do_action( 'action_scheduler_deleted_action', $action_id );
 
-		$this->last_deleted_action = $action_id;
-		add_action( 'action_scheduler/migrate_action_incomplete', array( $this, 'mark_migrated') );
-
 		if ( ! wp_delete_post( $action_id, TRUE ) ) {
 			$this->mark_migrated( $action_id );
 		}
-
-		remove_action( 'action_scheduler/migrate_action_incomplete', array( $this, 'mark_migrated') );
 	}
 
 	/**
@@ -798,14 +790,12 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	 * @param int $action_id Action ID.
 	 */
 	public function mark_migrated( $action_id ) {
-		if ( $action_id === $this->last_deleted_action ) {
-			wp_update_post(
-				array(
-					'ID'          => $action_id,
-					'post_status' => 'migrated'
-				)
-			);
-		}
+		wp_update_post(
+			array(
+				'ID'          => $action_id,
+				'post_status' => 'migrated'
+			)
+		);
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -471,9 +471,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 		do_action( 'action_scheduler_deleted_action', $action_id );
 
-		if ( ! wp_delete_post( $action_id, TRUE ) ) {
-			$this->mark_migrated( $action_id );
-		}
+		wp_delete_post( $action_id, TRUE );
 	}
 
 	/**

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -90,6 +90,10 @@ class ActionMigrator {
 			$this->log_migrator->migrate( $source_action_id, $destination_action_id );
 			$this->source->delete_action( $source_action_id );
 
+			$test_action = $this->source->fetch_action( $source_action_id );
+			if ( ! is_a( $test_action, 'ActionScheduler_NullAction' ) ) {
+				throw new \RuntimeException( sprintf( __( 'Unable to remove source migrated action %s', 'action-scheduler' ), $source_action_id ) );
+			}
 			do_action( 'action_scheduler/migrated_action', $source_action_id, $destination_action_id, $this->source, $this->destination );
 
 			return $destination_action_id;

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -95,6 +95,7 @@ class ActionMigrator {
 			return $destination_action_id;
 		} catch ( \Exception $e ) {
 			// could not delete from the old store
+			$this->source->mark_migrated( $source_action_id );
 			do_action( 'action_scheduler/migrate_action_incomplete', $source_action_id, $destination_action_id, $this->source, $this->destination );
 			do_action( 'action_scheduler/migrated_action', $source_action_id, $destination_action_id, $this->source, $this->destination );
 


### PR DESCRIPTION
Closes #398 

This PR changed the post status of an action to `migrated` when deleting the post after migration fails. This is a simpler fix than adding post meta as the status change removes the action from the migration queries. 

Using post meta would have added complexity to both the data store and the queries as the data store doesn't currently have any support for meta.