### PR TITLE
add post store args length dependency check

### DIFF
--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -44,7 +44,8 @@ class ActionScheduler_DataController {
 	 * @return bool
 	 */
 	public static function dependencies_met() {
-		return version_compare( PHP_VERSION, self::MIN_PHP_VERSION, '>=' );
+		$php_support = version_compare( PHP_VERSION, self::MIN_PHP_VERSION, '>=' );
+		return $php_support && apply_filters( 'action_scheduler_migration_dependencies_met', true );
 	}
 
 	/**


### PR DESCRIPTION
Closes #401

This PR adds a dependency check filter `action_scheduler_migration_dependencies_met`. The post store hooks this filter and queries the database for actions that have `$args` longer than the 191 character limit in the custom table store.