### PR TITLE
bump schema and plugin versions

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.0.0
+ * Version: 3.0.1
  * License: GPLv3
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
@@ -25,28 +25,28 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_0_dot_0' ) ) {
+if ( ! function_exists( 'action_scheduler_register_3_dot_0_dot_1' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_0_dot_0', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_0_dot_1', 0, 0 );
 
-	function action_scheduler_register_3_dot_0_dot_0() {
+	function action_scheduler_register_3_dot_0_dot_1() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.0.0', 'action_scheduler_initialize_3_dot_0_dot_0' );
+		$versions->register( '3.0.1', 'action_scheduler_initialize_3_dot_0_dot_1' );
 	}
 
-	function action_scheduler_initialize_3_dot_0_dot_0() {
+	function action_scheduler_initialize_3_dot_0_dot_1() {
 		require_once( 'classes/abstracts/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
-		action_scheduler_register_3_dot_0_dot_0();
+		action_scheduler_register_3_dot_0_dot_1();
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}

--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -13,17 +13,17 @@
 abstract class ActionScheduler_Abstract_Schema {
 
 	/**
-	 * @var int Increment this value to trigger a schema update
+	 * @var int Increment this value in derived class to trigger a schema update.
 	 */
 	protected $schema_version = 1;
 
 	/**
-	 * @var array Names of tables that will be registered by this class
+	 * @var array Names of tables that will be registered by this class.
 	 */
 	protected $tables = [];
 
 	/**
-	 * Register tables with WordPress, and create them if needed
+	 * Register tables with WordPress, and create them if needed.
 	 *
 	 * @return void
 	 */

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -10,7 +10,10 @@
 class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 	const LOG_TABLE = 'actionscheduler_logs';
 
-	protected $schema_version = 1;
+	/**
+	 * @var int Increment this value to trigger a schema update.
+	 */
+	protected $schema_version = 2;
 
 	public function __construct() {
 		$this->tables = [

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -12,7 +12,10 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	const CLAIMS_TABLE  = 'actionscheduler_claims';
 	const GROUPS_TABLE  = 'actionscheduler_groups';
 
-	protected $schema_version = 1;
+	/**
+	 * @var int Increment this value to trigger a schema update.
+	 */
+	protected $schema_version = 2;
 
 	public function __construct() {
 		$this->tables = [


### PR DESCRIPTION
This PR bumps the schema version for both the DB Store and DB Logger. The plugin version bump will allow this to be used to supersede the 3.0 version included WCS. 

The reason for the bump is that some installs that had had the RC installed removed the RC and dropped the tables but left the DB version settings. The schema bump will ensure the tables exist.

### Testing

- Ensure your schema settings are in place

```
$ wp option get schema-ActionScheduler_StoreSchema
1.0.1578583888
$ wp option get schema-ActionScheduler_LoggerSchema
1.0.1578583888
```

- Check whether the migration is marked as complete

```
wp option get action_scheduler_migration_status
complete
```

- Drop the AS tables

```
mysql> drop table wp_actionscheduler_actions, wp_actionscheduler_groups, wp_actionscheduler_claims, wp_actionscheduler_logs;
```

- Activate this branch & load a dashboard screen.
- Repeat the test with 
  - an opposite migration status `complete` or not set
  - restore the schema version to 1.0.{timestamp}

- Check after each test to ensure that the tables are created and schema version is updated.