### PR TITLE
update travis configuration with current version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,29 +9,29 @@ dist: precise
 # Versions of PHP to test against
 php:
     - "5.3"
-    - "5.4"
-    - "5.5"
     - "5.6"
     - "7.0"
     - "7.1"
+    - "7.2"
+    - "7.3"
 
 # Specify versions of WordPress to test against
 # WP_VERSION = WordPress version number (use "master" for SVN trunk)
 # WP_MULTISITE = whether to test multisite (use either "0" or "1")
 env:
-    - WP_VERSION=4.8 WP_MULTISITE=0
-    - WP_VERSION=4.7 WP_MULTISITE=0
-    - WP_VERSION=4.6 WP_MULTISITE=0
-    - WP_VERSION=4.8 WP_MULTISITE=1
-    - WP_VERSION=4.7 WP_MULTISITE=1
-    - WP_VERSION=4.6 WP_MULTISITE=1
+    - WP_VERSION=5.3 WP_MULTISITE=0
+    - WP_VERSION=5.2 WP_MULTISITE=0
+    - WP_VERSION=5.1 WP_MULTISITE=0
+    - WP_VERSION=5.3 WP_MULTISITE=1
+    - WP_VERSION=5.2 WP_MULTISITE=1
+    - WP_VERSION=5.1 WP_MULTISITE=1
 
 # Grab the setup script and execute
 before_script:
     - source tests/travis/setup.sh $TRAVIS_PHP_VERSION
 
 script:
- - if [[ "$TRAVIS_PHP_VERSION" == "7.1" ]] && [[ "$WP_VERSION" == "4.8" ]] && [[ "$WP_MULTISITE" == "0" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]; then phpunit --configuration tests/phpunit.xml.dist --coverage-clover clover.xml; else phpunit --configuration tests/phpunit.xml.dist; fi
+ - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]] && [[ "$WP_VERSION" == "5.3" ]] && [[ "$WP_MULTISITE" == "0" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]; then phpunit --configuration tests/phpunit.xml.dist --coverage-clover clover.xml; else phpunit --configuration tests/phpunit.xml.dist; fi
 
 after_script:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,14 @@ env:
     - WP_VERSION=5.2 WP_MULTISITE=1
     - WP_VERSION=5.1 WP_MULTISITE=1
 
+# WordPress 5.3 requires PHP 5.6. Exclude WP 5.3 + PHP 5.3
+jobs:
+  exclude:
+    - php: "5.3"
+      env: WP_VERSION=5.3 WP_MULTISITE=0
+    - php: "5.3"
+      env: WP_VERSION=5.3 WP_MULTISITE=1
+
 # Grab the setup script and execute
 before_script:
     - source tests/travis/setup.sh $TRAVIS_PHP_VERSION


### PR DESCRIPTION
This PR updates the WP & PHP versions in the test matrix. The test matrix was last changed 3 years ago.