### PR TITLE
Apply filter to empty args column

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -252,7 +252,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	public function column_args( array $row ) {
 		if ( empty( $row['args'] ) ) {
-			return '';
+			return apply_filters( 'action_scheduler_list_table_column_args', '', $row );
 		}
 
 		$row_html = '<ul>';


### PR DESCRIPTION
This enables displaying externally stored meta data.

I can also move the condition around to only call the `action_scheduler_list_table_column_args` filter once, if preferred.