### PR TITLE
add check that demarkation ID was set in actions table

### DIFF
--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -85,6 +85,24 @@ class ActionScheduler_HybridStore extends Store {
 					'status'    => '',
 				]
 			);
+			// Verify the correct action_id was set.
+			$table_name = $wpdb->{ActionScheduler_StoreSchema::ACTIONS_TABLE};
+			$action_id = $wpdb->get_var( "SELECT MAX(action_id) FROM {$table_name}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// If it's lower use an update to set it.
+			if ( $action_id < $this->demarkation_id ) {
+				$wpdb->update(
+					$wpdb->{ActionScheduler_StoreSchema::ACTIONS_TABLE},
+					[
+						'action_id' => $this->demarkation_id,
+					],
+					[
+						'action_id' => $action_id,
+					],
+					'%d',
+					'%d'
+				);
+			}
+
 			$wpdb->delete(
 				$wpdb->{ActionScheduler_StoreSchema::ACTIONS_TABLE},
 				[ 'action_id' => $this->demarkation_id ]


### PR DESCRIPTION
Fixes #437

This PR adds a check that the next identity value gets set on the `_actions` table. 

I'm not sure what conditions could be used to prevent the identity field being set on `INSERT` so I don't have steps to reproduce the issue.

