### PR TITLE
move action_execute hook to after status check

### DIFF
--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -48,7 +48,7 @@ abstract class ActionScheduler_Logger {
 	public function init() {
 		$this->hook_stored_action();
 		add_action( 'action_scheduler_canceled_action', array( $this, 'log_canceled_action' ), 10, 1 );
-		add_action( 'action_scheduler_before_execute', array( $this, 'log_started_action' ), 10, 2 );
+		add_action( 'action_scheduler_begin_execute', array( $this, 'log_started_action' ), 10, 2 );
 		add_action( 'action_scheduler_after_execute', array( $this, 'log_completed_action' ), 10, 3 );
 		add_action( 'action_scheduler_failed_execution', array( $this, 'log_failed_action' ), 10, 3 );
 		add_action( 'action_scheduler_failed_action', array( $this, 'log_timed_out_action' ), 10, 2 );


### PR DESCRIPTION
This PR replaces the existing `action_scheduler_before_execute` with `action_scheduler_before_process`. It moves `action_scheduler_before_execute` to after the action status has been checked which ensures that the `$action_id` is the ID of a valid action. 

It also makes the `action_scheduler_failed_execution` hook conditional on `$action_id` referencing a valid pending action.

In master, when invalid action IDs are passed to the queue runner, two log entries are written to the action log table. If there is a conflict where the queue runner is consistently being passed an invalid action ID, over time the async runner will insert large numbers of log entries into the table.

The approach of moving the timing of the hooks should maintain compatibility with custom data stores while eliminating the default behaviour of writing log entries for invalid action IDs.