### PR TITLE
add composer autoloading

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -40,7 +40,14 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_0_dot_1' ) ) {
 	}
 
 	function action_scheduler_initialize_3_dot_0_dot_1() {
-		require_once( 'classes/abstracts/ActionScheduler.php' );
+		$autoloader = __DIR__ . '/vendor/autoload.php';
+		if ( is_readable( $autoloader ) ) {
+			require_once( $autoloader );
+			define( 'AS_COMPOSER_AUTOLOADING', true );
+		} else {
+			define( 'AS_COMPOSER_AUTOLOADING', false );
+			require_once( 'classes/abstracts/ActionScheduler.php' );
+		}
 		ActionScheduler::init( __FILE__ );
 	}
 

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -104,12 +104,13 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 			return;
 		}
 
+		$as_version = ActionScheduler_Versions::instance()->latest_version();
 		$screen->add_help_tab(
 			array(
 				'id'      => 'action_scheduler_about',
 				'title'   => __( 'About', 'action-scheduler' ),
 				'content' =>
-					'<h2>' . __( 'About Action Scheduler', 'action-scheduler' ) . '</h2>' .
+					'<h2>' . sprintf( __( 'About Action Scheduler %s', 'action-scheduler' ), $as_version ) . '</h2>' .
 					'<p>' .
 						__( 'Action Scheduler is a scalable, traceable job queue for background processing large sets of actions. Action Scheduler works by triggering an action hook to run at some time in the future. Scheduled actions can also be scheduled to run on a recurring schedule.', 'action-scheduler' ) .
 					'</p>',

--- a/classes/ActionScheduler_wcSystemStatus.php
+++ b/classes/ActionScheduler_wcSystemStatus.php
@@ -92,12 +92,22 @@ class ActionScheduler_wcSystemStatus {
 	 * @param array $oldest_and_newest Date of the oldest and newest action with each status.
 	 */
 	protected function get_template( $status_labels, $action_counts, $oldest_and_newest ) {
+		$as_version = ActionScheduler_Versions::instance()->latest_version();
+		$autoloader = AS_COMPOSER_AUTOLOADING ? __( 'Composer', 'action-scheduler' ) : __( 'Internal', 'action-scheduler' );
 		?>
 
 		<table class="wc_status_table widefat" cellspacing="0">
 			<thead>
 				<tr>
 					<th colspan="5" data-export-label="Action Scheduler"><h2><?php esc_html_e( 'Action Scheduler', 'action-scheduler' ); ?><?php echo wc_help_tip( esc_html__( 'This section shows scheduled action counts.', 'action-scheduler' ) ); ?></h2></th>
+				</tr>
+				<tr>
+					<td colspan="2" data-export-label="Version"><?php esc_html_e( 'Version:', 'action-scheduler' ); ?></td>
+					<td colspan="3"><?php echo esc_html( $as_version ); ?></td>
+				</tr>
+				<tr>
+					<td colspan="2" data-export-label="Version"><?php esc_html_e( 'Autoloader:', 'action-scheduler' ); ?></td>
+					<td colspan="3"><?php echo esc_html( $autoloader ); ?></td>
 				</tr>
 				<tr>
 					<td><strong><?php esc_html_e( 'Action Status', 'action-scheduler' ); ?></strong></td>

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -130,7 +130,9 @@ abstract class ActionScheduler {
 	 */
 	public static function init( $plugin_file ) {
 		self::$plugin_file = $plugin_file;
-		spl_autoload_register( array( __CLASS__, 'autoload' ) );
+		if ( ! AS_COMPOSER_AUTOLOADING ) {
+			spl_autoload_register( array( __CLASS__, 'autoload' ) );
+		}
 
 		/**
 		 * Fires in the early stages of Action Scheduler init hook.

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,12 @@
       "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
       "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
     }
+  },
+  "autoload": {
+    "classmap": [
+      "classes/",
+      "deprecated/",
+      "lib/"
+    ]
   }
 }


### PR DESCRIPTION
Fixes #434 

This PR adds composer autoloading. The existing autoloading code is the fallback when `composer install` has not been run which should avoid any backward compatibility issues.

### Testing

1. Add an `error_log()` to `ActionScheduler::autoload()` where a class file is included.
1. Test the following matrix

#### Steps
1. Schedule an action with `as_schedule_single_action()`
1. Schedule an action with `as_schedule_cron_action()`
1. Load the Admin screen
1. Test WP CLI `wp action-scheduler run`

__Against__
 
#### Setup
1. Remove the `vendor` folder
  - This should log to the debug log as classes are loaded
1. Run `composer install --no-dev`
  - This should not log to the debug log
1. Run `composer install`
  - This should not log to the debug log
