### PR TITLE
ensure plugin is initialized on activation

### DIFF
--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -154,6 +154,14 @@ abstract class ActionScheduler {
 		$admin_view = self::admin_view();
 		add_action( 'init', array( $admin_view, 'init' ), 0, 0 ); // run before $store::init()
 
+		// Ensure initialization on plugin activation.
+		if ( did_action( 'init' ) ) {
+			$store->init();
+			$logger->init();
+			$runner->init();
+			$admin_view->init();
+		}
+
 		if ( apply_filters( 'action_scheduler_load_deprecated_functions', true ) ) {
 			require_once( self::plugin_path('deprecated/functions.php') );
 		}


### PR DESCRIPTION
Fixes #447 

This PR adds a check for the `init` hook having already been run when hooking up the data stores.

### Testing Instructions

- To reproduce the issue
  - Install WooCommerce `master`
  - drop the AS tables
  - delete the `schema%` options
  - delete the `action_scheduler_migration_complete` option
  - activate WooCommerce
- Switch to this branch & repeat the steps above 