### PR TITLE
Allow alternate storage engine

### DIFF
--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -16,7 +16,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	private static $store = NULL;
 
 	/** @var int */
-	private static $max_index_length = 191;
+	protected static $max_args_length = 191;
 
 	/**
 	 * @param ActionScheduler_Action $action
@@ -217,14 +217,14 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * InnoDB indexes have a maximum size of 767 bytes by default, which is only 191 characters with utf8mb4.
 	 *
 	 * Previously, AS wasn't concerned about args length, as we used the (unindex) post_content column. However,
-	 * as we prepare to move to custom tables, and can use an indexed VARCHAR column instead, we want to warn
-	 * developers of this impending requirement.
+	 * with custom tables, we use an indexed VARCHAR column instead.
 	 *
-	 * @param ActionScheduler_Action $action
+	 * @param  ActionScheduler_Action $action Action to be validated.
+	 * @throws InvalidArgumentException When json encoded args is too long.
 	 */
 	protected function validate_action( ActionScheduler_Action $action ) {
-		if ( strlen( json_encode( $action->get_args() ) ) > self::$max_index_length ) {
-			throw new InvalidArgumentException( __( 'ActionScheduler_Action::$args too long. To ensure the args column can be indexed, action args should not be more than 191 characters when encoded as JSON.', 'action-scheduler' ) );
+		if ( strlen( json_encode( $action->get_args() ) ) > static::$max_args_length ) {
+			throw new InvalidArgumentException( sprintf( __( 'ActionScheduler_Action::$args too long. To ensure the args column can be indexed, action args should not be more than %d characters when encoded as JSON.', 'action-scheduler' ), static::$max_args_length ) );
 		}
 	}
 

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -809,9 +809,11 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 		$dependencies_met = get_transient( self::DEPENDENCIES_MET );
 		if ( empty( $dependencies_met ) ) {
-			$found_action = $wpdb->get_var(
+			$maximum_args_length = apply_filters( 'action_scheduler_maximum_args_length', 191 );
+			$found_action        = $wpdb->get_var(
 				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND CHAR_LENGTH(post_content) > 191 LIMIT 1",
+					"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND CHAR_LENGTH(post_content) > %d LIMIT 1",
+					$maximum_args_length,
 					self::POST_TYPE
 				)
 			);

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -25,7 +25,6 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 		global $wpdb;
 		$table_name       = $wpdb->$table;
 		$charset_collate  = $wpdb->get_charset_collate();
-		$max_index_length = 191; // @see wp_get_db_schema()
 		switch ( $table ) {
 
 			case self::LOG_TABLE:

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -15,7 +15,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 2;
+	protected $schema_version = 3;
 
 	public function __construct() {
 		$this->tables = [
@@ -47,6 +47,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        last_attempt_gmt datetime NOT NULL default '0000-00-00 00:00:00',
 				        last_attempt_local datetime NOT NULL default '0000-00-00 00:00:00',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
+				        extended_args varchar(8000) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
 				        KEY hook (hook($max_index_length)),
 				        KEY status (status),


### PR DESCRIPTION
Fixes #418 

This PR 
- Updates the base store class to allow a datastore to set the maximum `$args` length on an action
- Updates the table store to support a maximum of 8000 characters encoded. The maximum record length is 65535 bytes (excluding `*text` fields). 8000 * 4 (for utf8mb4) = 32000 bytes. 8000 is the largest we should go without switching to a `*text` field.
- It does not remove the deprecated warning on the args length in the post store

### Testing Procedure

- Switch to AS tag 2.2.5
- Deactivate WC 4.0 beta and WC Subscriptions 3.0 if on those versions
- Add the following snippet 
```
add_action( 'init', function() {
	$action_id = as_schedule_single_action( time() + 50, 'test_action', range( 100, 150 ) );
	error_log( 'test_action: ' . $action_id );
	$found_action = as_next_scheduled_action( 'test_action', range( 100, 150 ) );
	error_log( 'Schedule: ' . gmdate( 'Y-m-d H:i:s O', $found_action ) );
} );
```
- This will log to the debug log
```
[10-Feb-2020 19:48:04 UTC] PHP Notice:  ActionScheduler_Action::$args was called <strong>incorrectly</strong>. To ensure the action args column can be indexed, action args should not be more than 191 characters when encoded as JSON. Support for strings longer than this will be removed in a future version. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 2.1.0.) in /Sites/ron/wp-includes/functions.php on line 4986
[10-Feb-2020 19:48:04 UTC] test_action: 11084
[10-Feb-2020 19:48:04 UTC] Schedule: 2020-02-10 19:48:48 +0000
```
- If your migration was already complete `wp option delete action_scheduler_migration_status`
- Switch to this branch
- Refresh the dashboard then disable the snippet above
- Debug log should have
```
[10-Feb-2020 19:48:04 UTC] test_action: 12345
[10-Feb-2020 19:48:04 UTC] Schedule: 2020-02-10 19:48:48 +0000
```
- After allowing the migration to run 
- Check that test actions created on 2.2.5 are migrated (the original action ID can be found in the migration entry on the action log).
- Check that test actions created on this branch are there 

- go to Tools -> Scheduled actions
- enter `149` in the search box
- `test_action` actions should be found 
