### PR TITLE
Remove the page and search string from status links in list table

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -606,6 +606,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 			}
 
 			$status_filter_url   = ( 'all' === $status_name ) ? remove_query_arg( 'status' ) : add_query_arg( 'status', $status_name );
+			$status_filter_url   = remove_query_arg( array( 'paged', 's' ), $status_filter_url );
 			$status_list_items[] = sprintf( $status_list_item, esc_attr( $status_name ), esc_url( $status_filter_url ), esc_html( ucfirst( $status_name ) ), absint( $count ) );
 		}
 


### PR DESCRIPTION
This PR fixes an issue in the list table where the status links show a number of actions but when clicked load an empty table.

### Reproduce the issue

- Create a few pending actions in `master` with a schedule an hour in the future
- Go to Tools -> Scheduled Actions
- Go to last page of `All`
- Click `Pending`
- Go to `All`
- Search for one of the pending actions from above
- Click `Complete`

### Testing

- Repeat the steps above with this branch