### PR TITLE
unhook async request dispatch after dispatching request

### DIFF
--- a/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -69,6 +69,7 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 		}
 
 		$this->dispatch();
+		ActionScheduler_QueueRunner::instance()->unhook_dispatch_async_request();
 	}
 
 	/**

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -65,8 +65,21 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 		}
 
 		add_action( self::WP_CRON_HOOK, array( self::instance(), 'run' ) );
+		$this->hook_dispatch_async_request();
+	}
 
-		add_filter( 'shutdown', array( $this, 'maybe_dispatch_async_request' ) );
+	/**
+	 * Hook check for dispatching an async request.
+	 */
+	public function hook_dispatch_async_request() {
+		add_action( 'shutdown', array( $this, 'maybe_dispatch_async_request' ) );
+	}
+
+	/**
+	 * Unhook check for dispatching an async request.
+	 */
+	public function unhook_dispatch_async_request() {
+		remove_action( 'shutdown', array( $this, 'maybe_dispatch_async_request' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #457 

This PR unhooks `maybe_dispatch_async_request()` after dispatching an async request. This will prevent a second thread from attempting to disptch another async request.