### PR TITLE
Remove .editorconfig from the export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 docs export-ignore
 tests export-ignore
 codecov.yml export-ignore
+.editorconfig export-ignore
 .github export-ignore
 .travis.yml export-ignore
 .gitattributes export-ignore


### PR DESCRIPTION
It's a dev file, and other dev files were previously added to the ignore list.

Fix #461.