### PR TITLE
always hook initialize_latest_version()

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -29,9 +29,9 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_0' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
-		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
+	add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_1_dot_0', 0, 0 );
 
 	function action_scheduler_register_3_dot_1_dot_0() {


### PR DESCRIPTION
See #464 

This PR is to address 

> You need to explicitly require AS main file, and do it BEFORE composer autoload, like this:

```
require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
require_once __DIR__ . '/vendor/autoload.php';
```

If a Composer autoloader is already active in the containing plugin then the `class_exists( 'ActionScheduler_Versions' )` check returns `true`. Because that check returns true, `initialize_latest_version` does not get hooked. Before adding a hook, WP checks whether it has already been hooked so adding a hook multiple times will not cause it to be executed multiple times.

### Testing Instructions

- Check out https://github.com/woocommerce/woocommerce-admin/pull/3557
- `npm install`
- `composer install`
- deactivate all plugins except WC & WC Admin
- add an action
```
add_action( 'init', function() {
	$action_id = as_schedule_single_action( time() + 50, 'function_check' );
} );
```
- load the dashboard should produce a fatal error
- copy `action-scheduler.php` from this branch to the `woocommerce-admin/external/action-scheduler` folder
- dashboard should load
- activate AS in this branch
- there should be no errors in the debug log