### PR TITLE
Unmark migration when a plugin is deactivated to prevent action loss.

### DIFF
--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -65,6 +65,15 @@ class ActionScheduler_DataController {
 	}
 
 	/**
+	 * Unmark migration when a plugin is de-activated. Will not work in case of silent activation, for example in an update.
+	 * We do this to mitigate the bug of lost actions which happens if there was an AS 2.x to AS 3.x migration in the past, but that plugin is now
+	 * deactivated and the site was running on AS 2.x again.
+	 */
+	public static function mark_migration_incomplete() {
+		delete_option( self::STATUS_FLAG );
+	}
+
+	/**
 	 * Set the action store class name.
 	 *
 	 * @param string $class Classname of the store class.
@@ -157,6 +166,7 @@ class ActionScheduler_DataController {
 		if ( self::is_migration_complete() ) {
 			add_filter( 'action_scheduler_store_class', array( 'ActionScheduler_DataController', 'set_store_class' ), 100 );
 			add_filter( 'action_scheduler_logger_class', array( 'ActionScheduler_DataController', 'set_logger_class' ), 100 );
+			add_action( 'deactivate_plugin', array( 'ActionScheduler_DataController', 'mark_migration_incomplete' ) );
 		} elseif ( self::dependencies_met() ) {
 			Controller::init();
 		}


### PR DESCRIPTION
If a plugin that loads AS 3.x is deactivated, flag for migration completed still remains. This means that if remaining plugins have highest active AS version of 2.x, then in future if a plugin with AS 3.x is installed, migration routine will not kick in because migration flag was already set.

An example of this is when WC Services with loads AS 3.x is disabled and WC 3.9 is enabled on the site, then this effectively downgrades AS from 3.x to 2.x. Then if WC is updated from 3.x to 4.x, action migration will not kick in because migration was marked completed by WC services back when it was updated/installed.

Also, since we cannot reliably determine what AS version will remain after deactivation, hook is triggered for all plugin deactivations.