### PR TITLE
Update docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,14 +33,14 @@ Enqueue an action to run one time, as soon as possible.
 ### Usage
 
 ```php
-as_enqueue_async_action( $hook, $args, $group )
-````
+as_enqueue_async_action( $hook, $args, $group );
+```
 
 ### Parameters
 
-- **$hook** (string)(required) Name of the action hook. Default: _none_.
+- **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
-- **$group** (array) The group to assign this job to. Default: _''_.
+- **$group** (string) The group to assign this job to. Default: _''_.
 
 ### Return value
 
@@ -56,15 +56,15 @@ Schedule an action to run one time at some defined point in the future.
 ### Usage
 
 ```php
-as_schedule_single_action( $timestamp, $hook, $args, $group )
-````
+as_schedule_single_action( $timestamp, $hook, $args, $group );
+```
 
 ### Parameters
 
-- **$timestamp** (integer)(required) The Unix timestamp representing the date you want the action to run. Default: _none_.
-- **$hook** (string)(required) Name of the action hook. Default: _none_.
+- **$timestamp** (integer)(required) The Unix timestamp representing the date you want the action to run.
+- **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
-- **$group** (array) The group to assign this job to. Default: _''_.
+- **$group** (string) The group to assign this job to. Default: _''_.
 
 ### Return value
 
@@ -80,16 +80,16 @@ Schedule an action to run repeatedly with a specified interval in seconds.
 ### Usage
 
 ```php
-as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group )
-````
+as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
+```
 
 ### Parameters
 
-- **$timestamp** (integer)(required) The Unix timestamp representing the date you want the action to run. Default: _none_.
-- **$interval_in_seconds** (integer)(required) How long to wait between runs. Default: _none_.
-- **$hook** (string)(required) Name of the action hook. Default: _none_.
+- **$timestamp** (integer)(required) The Unix timestamp representing the date you want the action to run.
+- **$interval_in_seconds** (integer)(required) How long to wait between runs.
+- **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
-- **$group** (array) The group to assign this job to. Default: _''_.
+- **$group** (string) The group to assign this job to. Default: _''_.
 
 ### Return value
 
@@ -105,16 +105,16 @@ Schedule an action that recurs on a cron-like schedule.
 ### Usage
 
 ```php
-as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group )
-````
+as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group );
+```
 
 ### Parameters
 
-- **$timestamp** (integer)(required) The Unix timestamp representing the date you want the action to run. Default: _none_.
-- **$schedule** (string)(required) $schedule A cron-link schedule string, see http://en.wikipedia.org/wiki/Cron. Default: _none_.
-- **$hook** (string)(required) Name of the action hook. Default: _none_.
+- **$timestamp** (integer)(required) The Unix timestamp representing the date you want the action to run.
+- **$schedule** (string)(required) $schedule A cron-like schedule string, see http://en.wikipedia.org/wiki/Cron.
+- **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
-- **$group** (array) The group to assign this job to. Default: _''_.
+- **$group** (string) The group to assign this job to. Default: _''_.
 
 ### Return value
 
@@ -130,14 +130,14 @@ Cancel the next occurrence of a scheduled action.
 ### Usage
 
 ```php
-as_unschedule_action( $hook, $args, $group )
-````
+as_unschedule_action( $hook, $args, $group );
+```
 
 ### Parameters
 
-- **$hook** (string)(required) Name of the action hook. Default: _none_.
+- **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments passed to callbacks when the hook triggers. Default: _`array()`_.
-- **$group** (array) The group job was assigned to. Default: _''_.
+- **$group** (string) The group job was assigned to. Default: _''_.
 
 ### Return value
 
@@ -152,14 +152,14 @@ Cancel all occurrences of a scheduled action.
 ### Usage
 
 ```php
-as_unschedule_action( $hook, $args, $group )
-````
+as_unschedule_action( $hook, $args, $group );
+```
 
 ### Parameters
 
 - **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
-- **$group** (array) The group to assign this job to. Default: _''_.
+- **$group** (string) The group to assign this job to. Default: _''_.
 
 ### Return value
 
@@ -175,14 +175,14 @@ Returns the next timestamp for a scheduled action.
 ### Usage
 
 ```php
-as_next_scheduled_action( $hook, $args, $group )
-````
+as_next_scheduled_action( $hook, $args, $group );
+```
 
 ### Parameters
 
-- **$hook** (string)(required) Name of the action hook. Default: _none_.
+- **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
-- **$group** (array) The group to assign this job to. Default: _''_.
+- **$group** (string) The group to assign this job to. Default: _''_.
 
 ### Return value
 
@@ -198,8 +198,8 @@ Find scheduled actions.
 ### Usage
 
 ```php
-as_get_scheduled_actions( $args, $return_format )
-````
+as_get_scheduled_actions( $args, $return_format );
+```
 
 ### Parameters
 
@@ -221,4 +221,4 @@ as_get_scheduled_actions( $args, $return_format )
 
 ### Return value
 
-(array) Array of the actions matching the criteria specified with `$args`.
+(array) Array of action rows matching the criteria specified with `$args`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Action Scheduler is a library for triggering a WordPress hook to run at some tim
 
 Think of it like an extension to `do_action()` which adds the ability to delay and repeat a hook.
 
-It just so happens, this functionality also creates a robust job queue for background processing large queues of tasks in WordPress. With the additional of logging and an [administration interface](/admin/), that also provide tracability on your tasks processed in the background.
+It just so happens, this functionality also creates a robust job queue for background processing large queues of tasks in WordPress. With the addition of logging and an [administration interface](/admin/), it also provide tracability on your tasks processed in the background.
 
 ### Battle-Tested Background Processing
 
@@ -39,7 +39,7 @@ This process and the loopback requests will continue until all actions are proce
 
 Before processing a batch, the scheduler will remove any existing claims on actions which have been sitting in a queue for more than five minutes (or more specifically, 10 times the allowed time limit, which defaults to 30 seconds).
 
-Action Scheduler will also trash any actions which were completed or canceled more than a month ago.
+Action Scheduler will also delete any actions which were completed or canceled more than a month ago.
 
 If an action runs for more than 5 minutes, Action Scheduler will assume the action has timed out and will mark it as failed. However, if all callbacks attached to the action were to successfully complete sometime after that 5 minute timeout, its status would later be updated to completed.
 
@@ -58,8 +58,6 @@ The events logged by default include when an action:
  * fails
 
 If it fails with an error that can be recorded, that error will be recorded in the log and visible in administration interface, making it possible to trace what went wrong at some point in the past on a site you didn't have access to in the past.
-
-Actions can also be grouped together using a custom taxonomy named `action-group`.
 
 ## Credits
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,37 +9,6 @@ Using Action Scheduler requires:
 1. scheduling an action
 1. attaching a callback to that action
 
-## Scheduling an Action
-
-To schedule an action, call the [API function](/api/) for the desired schedule type passing in the required parameters.
-
-The example code below shows everything needed to schedule a function to run at midnight, if it's not already scheduled:
-
-```php
-require_once( plugin_dir_path( __FILE__ ) . '/libraries/action-scheduler/action-scheduler.php' );
-
-/**
- * Schedule an action with the hook 'eg_midnight_log' to run at midnight each day
- * so that our callback is run then.
- */
-function eg_schedule_midnight_log() {
-	if ( false === as_next_scheduled_action( 'eg_midnight_log' ) ) {
-		as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'eg_midnight_log' );
-	}
-}
-add_action( 'init', 'eg_schedule_midnight_log' );
-
-/**
- * A callback to run when the 'eg_midnight_log' scheduled action is run.
- */
-function eg_log_action_data() {
-	error_log( 'It is just after midnight on ' . date( 'Y-m-d' ) );
-}
-add_action( 'eg_midnight_log', 'eg_log_action_data' );
-```
-
-For more details on all available API functions, and the data they accept, refer to the [API Reference](/api/).
-
 ## Installation
 
 There are two ways to install Action Scheduler:
@@ -125,3 +94,34 @@ Action Scheduler will later initialize itself on `'init'` with priority `1`.  Ac
 ### Usage in Themes
 
 When using Action Scheduler in themes, it's important to note that if Action Scheduler has been registered by a plugin, then the latest version registered by a plugin will be used, rather than the version included in the theme. This is because of the version dependency handling code using `'plugins_loaded'` since version 1.0.
+
+## Scheduling an Action
+
+To schedule an action, call the [API function](/api/) for the desired schedule type passing in the required parameters.
+
+The example code below shows everything needed to schedule a function to run at midnight, if it's not already scheduled:
+
+```php
+require_once( plugin_dir_path( __FILE__ ) . '/libraries/action-scheduler/action-scheduler.php' );
+
+/**
+ * Schedule an action with the hook 'eg_midnight_log' to run at midnight each day
+ * so that our callback is run then.
+ */
+function eg_schedule_midnight_log() {
+	if ( false === as_next_scheduled_action( 'eg_midnight_log' ) ) {
+		as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'eg_midnight_log' );
+	}
+}
+add_action( 'init', 'eg_schedule_midnight_log' );
+
+/**
+ * A callback to run when the 'eg_midnight_log' scheduled action is run.
+ */
+function eg_log_action_data() {
+	error_log( 'It is just after midnight on ' . date( 'Y-m-d' ) );
+}
+add_action( 'eg_midnight_log', 'eg_log_action_data' );
+```
+
+For more details on all available API functions, and the data they accept, refer to the [API Reference](/api/).

--- a/docs/version3-0.md
+++ b/docs/version3-0.md
@@ -12,7 +12,7 @@ Yes! The Action Scheduler Custom Tables plugin code is now part of Action Schedu
 
 By default, Action Scheduler will only initiate a migration from the internal `WPPostStore` data store. To enable migration from any custom datastore add the following filter `add_filter( 'action_scheduler_migrate_data_store', '__return_true' );`.
 
-### I'm currently on PHP >=5.5. When I update PHP will the migration start automatically?
+### I'm currently on PHP <5.5. When I update PHP will the migration start automatically?
 
 Yes! The migration is initiated as soon as all dependencies are met.
 

--- a/docs/version3-0.md
+++ b/docs/version3-0.md
@@ -12,13 +12,29 @@ Yes! The Action Scheduler Custom Tables plugin code is now part of Action Schedu
 
 By default, Action Scheduler will only initiate a migration from the internal `WPPostStore` data store. To enable migration from any custom datastore add the following filter `add_filter( 'action_scheduler_migrate_data_store', '__return_true' );`.
 
-### I'm currently on PHP <5.5. When I update PHP will the migration start automatically?
+### I'm currently on PHP >=5.5. When I update PHP will the migration start automatically?
 
 Yes! The migration is initiated as soon as all dependencies are met.
 
 ### I would like to update a plugin for testing that includes Action Scheduler 3.0 but would like to postpone the migration until that testing is complete. Is that possible?
 
 Yes, while we recommend migrating to custom tables as soon as possible for performance reasons, you can use `add_filter( 'action_scheduler_migration_dependencies_met', '__return_false' );` to prevent the migration from initiating.
+
+### I updated to Action Scheduler 3.0+, the migration is running, and I'm seeing a lot of `admin-ajax.php?action=as_async_request_queue` requests. Is it possible to reduce this load?
+
+You can increase the delay (in seconds) between these requests with
+
+```
+add_filter( 'action_scheduler_async_request_sleep_seconds', function( $sleep ) {
+	return 10;
+} );
+```
+
+The default value for this filter is `1` in versions 3.0.X and `5` in versions 3.1.X.
+
+Alternatively, the async queue runner can be disabled while your migration is in process with `add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );`.
+
+Once the migration is complete, these filters should be removed.
 
 ### Is there a strong likelihood of migration issues with any of the above?
 
@@ -35,7 +51,7 @@ If you wish to undertake more comprehensive testing on a development or staging 
 1. Take a screenshot of the action status counts at the top of the page. Example screenshot: https://cld.wthms.co/kwIqv7
 
 
-#### Stage 2: Install & Activate Action Scheduler 3.0 as a plugin
+#### Stage 2: Install & Activate Action Scheduler 3.0+ as a plugin
 
 1. The migration will start almost immediately
 1. Keep an eye on your error log

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -19,6 +19,10 @@ If you choose to utilize WP CLI exclusively, you can disable the normal WP CLI q
 
 These are the commands available to use with Action Scheduler:
 
+* `action-scheduler migrate`
+
+    **Note**: This command is only available while the migration to custom tables is in progress.
+
 * `action-scheduler run`
     
     Options:


### PR DESCRIPTION
Update documentation in the docs folder:

- Remove `Default: None` on required parameters.
- Added `;` where appropriate in sample code.
- Fixed parameter type for group.
- Remove extra back ticks in api docs.
- Add the CLI `migrate` command.
- Other wording fixes.

Fixes #438 
Fixes #432