### PR TITLE
restore action handling to WC status, use data store to delete actions

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -91,6 +91,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	 */
 	public function render_admin_ui() {
 		$table = new ActionScheduler_ListTable( ActionScheduler::store(), ActionScheduler::logger(), ActionScheduler::runner() );
+		$table->process_actions();
 		$table->display_page();
 	}
 

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -10,6 +10,9 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
 	private static $screen_id = 'tools_page_action-scheduler';
 
+	/** @var ActionScheduler_ListTable */
+	protected $list_table;
+
 	/**
 	 * @return ActionScheduler_AdminView
 	 * @codeCoverageIgnore
@@ -82,17 +85,29 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	 * Triggers processing of any pending actions.
 	 */
 	public function process_admin_ui() {
-		$table = new ActionScheduler_ListTable( ActionScheduler::store(), ActionScheduler::logger(), ActionScheduler::runner() );
-		$table->process_actions();
+		$this->get_list_table();
 	}
 
 	/**
 	 * Renders the Admin UI
 	 */
 	public function render_admin_ui() {
-		$table = new ActionScheduler_ListTable( ActionScheduler::store(), ActionScheduler::logger(), ActionScheduler::runner() );
-		$table->process_actions();
+		$table = $this->get_list_table();
 		$table->display_page();
+	}
+
+	/**
+	 * Get the admin UI object and process any requested actions.
+	 *
+	 * @return ActionScheduler_ListTable
+	 */
+	protected function get_list_table() {
+		if ( null === $this->list_table ) {
+			$this->list_table = new ActionScheduler_ListTable( ActionScheduler::store(), ActionScheduler::logger(), ActionScheduler::runner() );
+			$this->list_table->process_actions();
+		}
+
+		return $this->list_table;
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -140,7 +140,6 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 		global $wpdb;
 		// Detect when a bulk action is being triggered.
 		$action = $this->current_action();
-
 		if ( ! $action ) {
 			return;
 		}
@@ -161,13 +160,14 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Default code for deleting entries. We trust ids_sql because it is
+	 * Default code for deleting entries.
 	 * validated already by process_bulk_action()
 	 */
 	protected function bulk_delete( array $ids, $ids_sql ) {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$this->table_name} WHERE {$this->ID} IN $ids_sql" );
+		$store = ActionScheduler::store();
+		foreach ( $ids as $action_id ) {
+			$store->delete( $action_id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Closes #485 

This PR restores the action handling to the Scheduled Actions screen under WooCommerce -> Status -> Scheduled Actions. The handling was removed in #354. 

While investigating this I noticed that the bulk delete action attempts to delete the actions from the default data store. The PR updates that function to use the data store to delete the actions.

### Testing

1. In master confirm that neither the bulk delete action or the action links work in the WC status page
1. Switch to this branch
1. Update `action-scheduler.php` to artificially bump the version
```
-if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_2' ) ) {
+if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_3' ) ) {
 
        if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
                require_once( 'classes/ActionScheduler_Versions.php' );
                add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
        }
 
-       add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_1_dot_2', 0, 0 );
+       add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_1_dot_3', 0, 0 );
 
-       function action_scheduler_register_3_dot_1_dot_2() {
+       function action_scheduler_register_3_dot_1_dot_3() {
                $versions = ActionScheduler_Versions::instance();
-               $versions->register( '3.1.2', 'action_scheduler_initialize_3_dot_1_dot_2' );
+               $versions->register( '3.1.3', 'action_scheduler_initialize_3_dot_1_dot_3' );
        }
 
-       function action_scheduler_initialize_3_dot_1_dot_2() {
+       function action_scheduler_register_3_dot_1_dot_3() {
                $versions = ActionScheduler_Versions::instance();
-               $versions->register( '3.1.2', 'action_scheduler_initialize_3_dot_1_dot_2' );
+               $versions->register( '3.1.3', 'action_scheduler_initialize_3_dot_1_dot_3' );
        }
 
-       function action_scheduler_initialize_3_dot_1_dot_2() {
+       function action_scheduler_initialize_3_dot_1_dot_3() {
                require_once( 'classes/abstracts/ActionScheduler.php' );
                ActionScheduler::init( __FILE__ );
        }
 
        // Support usage in themes - load this version if no plugin has loaded a version yet.
        if ( did_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
-               action_scheduler_initialize_3_dot_1_dot_2();
+               action_scheduler_initialize_3_dot_1_dot_3();
                do_action( 'action_scheduler_pre_theme_init' );
                ActionScheduler_Versions::initialize_latest_version();
        }
```
1. Check the WC status report to verify the bumped version is active
1. Test action links and bulk actions in both the `Tools` and `WooCommerce -> Status` Scheduled Actions screens work.