### PR TITLE
add table missing notice with action link

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -512,8 +512,8 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 		$store_schema  = new ActionScheduler_StoreSchema();
 		$logger_schema = new ActionScheduler_StoreSchema();
-		$store_schema->register_tables( 'yes' );
-		$logger_schema->register_tables( 'yes' );
+		$store_schema->register_tables( true );
+		$logger_schema->register_tables( true );
 
 		remove_action( 'action_scheduler/created_table', array( $store, 'set_autoincrement' ), 10 );
 	}

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -549,6 +549,29 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Process table action from $_REQUEST.
+	 */
+	protected function process_table_actions() {
+		$parameters = array( 'table_action', 'nonce' );
+		foreach ( $parameters as $parameter ) {
+			if ( empty( $_REQUEST[ $parameter ] ) ) {
+				return;
+			}
+		}
+		$method = 'table_action_' . $_REQUEST['table_action'];
+
+		if ( $_REQUEST['nonce'] === wp_create_nonce( 'table_action::' . $_REQUEST[ 'table_action' ] ) && method_exists( $this, $method ) ) {
+			$this->$method();
+		}
+
+		wp_redirect( remove_query_arg(
+			array( 'table_action', 'nonce' ),
+			wp_unslash( $_SERVER['REQUEST_URI'] )
+		) );
+		exit;
+	}
+
+	/**
 	 * Default column formatting, it will escape everythig for security.
 	 */
 	public function column_default( $item, $column_name ) {
@@ -641,8 +664,8 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	 * Process any pending actions.
 	 */
 	public function process_actions() {
+		$this->process_table_actions();
 		$this->process_bulk_action();
-
 		$this->process_row_actions();
 
 		if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -549,29 +549,6 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Process table action from $_REQUEST.
-	 */
-	protected function process_table_actions() {
-		$parameters = array( 'table_action', 'nonce' );
-		foreach ( $parameters as $parameter ) {
-			if ( empty( $_REQUEST[ $parameter ] ) ) {
-				return;
-			}
-		}
-		$method = 'table_action_' . $_REQUEST['table_action'];
-
-		if ( $_REQUEST['nonce'] === wp_create_nonce( 'table_action::' . $_REQUEST[ 'table_action' ] ) && method_exists( $this, $method ) ) {
-			$this->$method();
-		}
-
-		wp_redirect( remove_query_arg(
-			array( 'table_action', 'nonce' ),
-			wp_unslash( $_SERVER['REQUEST_URI'] )
-		) );
-		exit;
-	}
-
-	/**
 	 * Default column formatting, it will escape everythig for security.
 	 */
 	public function column_default( $item, $column_name ) {
@@ -664,7 +641,6 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	 * Process any pending actions.
 	 */
 	public function process_actions() {
-		$this->process_table_actions();
 		$this->process_bulk_action();
 		$this->process_row_actions();
 

--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -25,11 +25,11 @@ abstract class ActionScheduler_Abstract_Schema {
 	/**
 	 * Register tables with WordPress, and create them if needed.
 	 *
-	 * @param string $force_update Optional. Default 'no'. Use 'yes' to run the schema update.
+	 * @param bool $force_update Optional. Default false. Use true to always run the schema update.
 	 *
 	 * @return void
 	 */
-	public function register_tables( $force_update = 'no' ) {
+	public function register_tables( $force_update = false ) {
 		global $wpdb;
 
 		// make WP aware of our tables
@@ -40,7 +40,7 @@ abstract class ActionScheduler_Abstract_Schema {
 		}
 
 		// create the tables
-		if ( $this->schema_update_required() || 'yes' === $force_update ) {
+		if ( $this->schema_update_required() || $force_update ) {
 			foreach ( $this->tables as $table ) {
 				$this->update_table( $table );
 			}

--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -25,9 +25,11 @@ abstract class ActionScheduler_Abstract_Schema {
 	/**
 	 * Register tables with WordPress, and create them if needed.
 	 *
+	 * @param string $force_update Optional. Default 'no'. Use 'yes' to run the schema update.
+	 *
 	 * @return void
 	 */
-	public function register_tables() {
+	public function register_tables( $force_update = 'no' ) {
 		global $wpdb;
 
 		// make WP aware of our tables
@@ -38,7 +40,7 @@ abstract class ActionScheduler_Abstract_Schema {
 		}
 
 		// create the tables
-		if ( $this->schema_update_required() ) {
+		if ( $this->schema_update_required() || 'yes' === $force_update ) {
 			foreach ( $this->tables as $table ) {
 				$this->update_table( $table );
 			}


### PR DESCRIPTION
Closes #491 

As reported in the issue, [WP Optimize](https://en-ca.wordpress.org/plugins/wp-optimize/) is prompting some users to delete the action scheduler tables. In #455, we bumped the schema version to ensure that tables would be created when updating to WooCommerce 4.0 if they had previously been created and deleted.

This PR adds a check to verify the AS tables exist to the Scheduled Actions screen. The check is conditional on the site using either the hybrid or internal table data store. If any of the 4 tables are missing. A dashboard notice is added with an action link to create the tables.

### Testing

- Ensure the migration is completed
- Rename `wp_actionscheduler_actions`
- Go to Tools -> Scheduled Actions
- Verify there are no actions listed, the missing tables message appears 
- Deactivate AS, activate WC 3.9.3
- Create an action with `as_schedule_single_action()`
- Drop `wp_actionscheduler_actions`
- Deactivate WC, activate AS
- Go to Tools -> Scheduled Actions same message should appear
- Action created above should be listed
- Restore original `wp_actionscheduler_actions`
