### PR TITLE
add null action check to list table display items

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -527,6 +527,9 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			} catch ( Exception $e ) {
 				continue;
 			}
+			if ( is_a( $action, 'ActionScheduler_NullAction' ) ) {
+				continue;
+			}
 			$this->items[ $action_id ] = array(
 				'ID'          => $action_id,
 				'hook'        => $action->get_hook(),


### PR DESCRIPTION
Closes #486 

This PR is a simpler alternative to #489. It adds a null action check in the list table. The affected action(s) still won't be accessible while the migration is in progress but this will allow access to the screen and allow the migration to complete.

Test using the steps in #489