### PR TITLE
prevent initialization on activation when AS is already initialized

### DIFF
--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -129,6 +129,13 @@ abstract class ActionScheduler {
 	 * @param string $plugin_file
 	 */
 	public static function init( $plugin_file ) {
+		/**
+		 * Prevent initialization during activation when there is already a version of AS active.
+		 */
+		if (  did_action( 'action_scheduler_pre_init' ) ) {
+			return;
+		}
+
 		self::$plugin_file = $plugin_file;
 		spl_autoload_register( array( __CLASS__, 'autoload' ) );
 


### PR DESCRIPTION
When Action Scheduler is activated as a standalone plugin, the `init` hook is already fired so for the duration of the activation process thread AS is active but not initialized.

If AS is a library in another WP plugin that has an activation hook then it might be initialized through that activation hook. #450 ensures that the AS data stores are initialized if used during the activation process. However, if AS is already active either standalone or in another plugin then two versions of AS are initialized at the same time. 

This PR prevents the initialization of AS during activation if another instance of AS has already been initialized.

### To produce this issue

- Install [AS 3.1.1](https://github.com/woocommerce/action-scheduler/archive/3.1.1.zip)
- Install WooCommerce 4.0
- Deactivate all plugins
- Activate AS 3.0.1
- Activate WooCommerce (with WP CLI if installed)
- Error shown via WP CLI (or check debug.log for Exception below)
```
Notice: Undefined property: wpdb::$actionscheduler_actions in /Users/ronrennick/Sites/ron/wp-includes/wp-db.php on line 659
Notice: Undefined property: wpdb::$actionscheduler_actions in /Users/ronrennick/Sites/ron/wp-includes/wp-db.php on line 659
Notice: Undefined property: wpdb::$actionscheduler_actions in /Users/ronrennick/Sites/ron/wp-includes/wp-db.php on line 659
Notice: Undefined property: wpdb::$actionscheduler_actions in /Users/ronrennick/Sites/ron/wp-includes/wp-db.php on line 659
Notice: Undefined property: wpdb::$actionscheduler_groups in /Users/ronrennick/Sites/ron/wp-includes/wp-db.php on line 659
Notice: Undefined property: wpdb::$actionscheduler_groups in /Users/ronrennick/Sites/ron/wp-includes/wp-db.php on line 659
Notice: Undefined property: wpdb::$actionscheduler_actions in /Users/ronrennick/Sites/ron/wp-includes/wp-db.php on line 659
Fatal error: Uncaught RuntimeException: Error saving action: Error saving action: Incorrect table name '' in /Sites/ron/wp-content/plugins/action-scheduler/classes/migration/ActionScheduler_DBStoreMigrator.php:44
Stack trace:
#0 /Sites/ron/wp-content/plugins/action-scheduler/classes/data-stores/ActionScheduler_HybridStore.php(225): ActionScheduler_DBStoreMigrator->save_action(Object(ActionScheduler_Action), NULL)
#1 /Sites/ron/wp-content/plugins/action-scheduler/classes/ActionScheduler_ActionFactory.php(177): ActionScheduler_HybridStore->save_action(Object(ActionScheduler_Action))
#2 /Sites/ron/wp-content/plugins/action-scheduler/classes/ActionScheduler_ActionFactory.php(84): ActionScheduler_ActionFactory->store(Object(ActionScheduler_Action))
#3 /Sites/ron/wp-content/plugins/action-scheduler/functions.php(30): ActionScheduler_ActionFactory->single('action_schedule...', Array, 1584464457, 'action-schedule...')
#4 /Users/ronrennick/Sites/r in /Sites/ron/wp-content/plugins/action-scheduler/classes/migration/ActionScheduler_DBStoreMigrator.php on line 44
```

- Copy this branch to `woocommerce/packages/action-scheduler`
- Repeat the steps above
- No errors should occur
