### PR TITLE
ensure valid table name on save action

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -56,7 +56,8 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 				$data['extended_args'] = $args;
 			}
 
-			$wpdb->insert( $wpdb->actionscheduler_actions, $data );
+			$table_name = ! empty( $wpdb->actionscheduler_actions ) ? $wpdb->actionscheduler_actions : $wpdb->prefix . 'actionscheduler_actions';
+			$wpdb->insert( $table_name, $data );
 			$action_id = $wpdb->insert_id;
 
 			if ( is_wp_error( $action_id ) ) {


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce/issues/25895

Supersedes #497 

In https://github.com/woocommerce/woocommerce/issues/25895#issuecomment-600404240, the user reported that deactivating a caching plugin eliminated the error.

We have not been able to reliable reproduce this error with just AS and WooCommerce. It has been reported multiple times in Github, WordPress.org forums and through support. In some installs, the `$wpdb->actionscheduler_actions` property is not set when the migration attempts to create an action while the Hybrid data store is active.

This PR mitigates that issue by adding a check to see if the property has a value. If not, it concatenates the table name using `$wpdb->prefix`.

### Testing

- Check that AS screen has actions
- Delete the `action_scheduler_migration_status` option
- Verify that the migration completes
- Check that AS screen has actions