### PR TITLE
tag version 3.1.4

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.1.3
+ * Version: 3.1.4
  * License: GPLv3
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
@@ -25,28 +25,28 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_3' ) ) {
+if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_4' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_1_dot_3', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_1_dot_4', 0, 0 );
 
-	function action_scheduler_register_3_dot_1_dot_3() {
+	function action_scheduler_register_3_dot_1_dot_4() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.1.3', 'action_scheduler_initialize_3_dot_1_dot_3' );
+		$versions->register( '3.1.4', 'action_scheduler_initialize_3_dot_1_dot_4' );
 	}
 
-	function action_scheduler_initialize_3_dot_1_dot_3() {
+	function action_scheduler_initialize_3_dot_1_dot_4() {
 		require_once( 'classes/abstracts/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
-		action_scheduler_initialize_3_dot_1_dot_3();
+		action_scheduler_initialize_3_dot_1_dot_4();
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "action-scheduler",
   "title": "Action Scheduler",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "homepage": "https://actionscheduler.org/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump. Draft release is prepared at https://github.com/woocommerce/action-scheduler/releases