### PR TITLE
Usage updates for as_unschedule_all_actions()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -152,7 +152,7 @@ Cancel all occurrences of a scheduled action.
 ### Usage
 
 ```php
-as_unschedule_action( $hook, $args, $group )
+as_unschedule_all_actions( $hook, $args, $group )
 ````
 
 ### Parameters


### PR DESCRIPTION
`as_unschedule_all_actions()` function usage was wrong. Updated the usage code block.