### PR TITLE
add untranslated status to list table row

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -307,7 +307,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * @return string
 	 */
 	protected function maybe_render_actions( $row, $column_name ) {
-		if ( 'pending' === strtolower( $row['status'] ) ) {
+		if ( 'pending' === strtolower( $row[ 'status_name' ] ) ) {
 			return parent::maybe_render_actions( $row, $column_name );
 		}
 
@@ -577,6 +577,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			$this->items[ $action_id ] = array(
 				'ID'          => $action_id,
 				'hook'        => $action->get_hook(),
+				'status_name' => $this->store->get_status( $action_id ),
 				'status'      => $status_labels[ $this->store->get_status( $action_id ) ],
 				'args'        => $action->get_args(),
 				'group'       => $action->get_group(),


### PR DESCRIPTION
Closes #506 

This PR adds the raw status name to the data row in the admin view list table. The translated status field was being used to determine whether to output action links.

### Testing

1. Copy this PR to WC 4.0.1 `packages/action-scheduler`
1. Run the translation update script in WC `composer run-script makepot`
1. Download the `dev` Spanish translation `.mo` of WooCommerce from https://translate.wordpress.org
1. Copy the downloaded file to `wp-content/languages/plugins/woocommerce-es_ES.mo`
1. Pending scheduled actions should appear as screenshot

<img width="627" alt="Screen Shot 2020-03-31 at 7 13 05 PM" src="https://user-images.githubusercontent.com/343847/78079993-ac7cee00-7383-11ea-83d0-5e4b237d6593.png">
