### PR TITLE
Fix default value for free-memory-on flag

### DIFF
--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -48,7 +48,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
 		$hooks   = array_filter( array_map( 'trim', $hooks ) );
 		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
-		$free_on = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', '' );
+		$free_on = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
 		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', '' );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 


### PR DESCRIPTION
The default value for the free-memory-on should be 50 as documented. Currently, if no value is given, no memory freeing attempts will be made. This might unintentionally cause problems with larger batches of e.g. Subscriptions payments.