### PR TITLE
Use correct defaults in WP CLI 

### DIFF
--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -101,7 +101,7 @@ class ActionScheduler_DataController {
 	 * @param integer $sleep_time The number of seconds to pause before resuming operation.
 	 */
 	public static function set_sleep_time( $sleep_time ) {
-		self::$sleep_time = $sleep_time;
+		self::$sleep_time = (int) $sleep_time;
 	}
 
 	/**
@@ -110,7 +110,7 @@ class ActionScheduler_DataController {
 	 * @param integer $free_ticks The number of ticks to free memory on.
 	 */
 	public static function set_free_ticks( $free_ticks ) {
-		self::$free_ticks = $free_ticks;
+		self::$free_ticks = (int) $free_ticks;
 	}
 
 	/**

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -49,7 +49,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$hooks   = array_filter( array_map( 'trim', $hooks ) );
 		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
 		$free_on = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
-		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', '' );
+		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
 		ActionScheduler_DataController::set_free_ticks( $free_on );

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -48,7 +48,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
 		$hooks   = array_filter( array_map( 'trim', $hooks ) );
 		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
-		$free_on = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', '' );
+		$free_on = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
 		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', '' );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 


### PR DESCRIPTION
This PR expands #524 with 

- `0` default sleep time
- cast passed `integer` parameters to `int`

In PHP 7.4, warnings occur when numeric strings are implicitly cast to numbers for operations. The original PR added the default of `pause` on `50` per the documentation.

### Testing

- Activate https://github.com/woocommerce/action-scheduler-disable-default-runner
- Use this snippet to create actions
```
add_action( 'init', function() {
	for ( $i = 1; $i < 100; $i++ ) {
	       as_enqueue_async_action( 'as-parameter-test' . $i );
        }
} );
```
- Run `wp action-scheduler run --pause=5`
- The output should pause at 50 actions for 5 seconds
- Modify the snippet above to create 10 actions
- Run `wp action-scheduler run --free-memory-on=2`
- The output should show freeing memory on intervals of 2 actions with no pause in execution
