### PR TITLE
add check for Null Schedule on canceled actions

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -22,7 +22,7 @@ class ActionScheduler_ActionFactory {
 				break;
 			case ActionScheduler_Store::STATUS_CANCELED :
 				$action_class = 'ActionScheduler_CanceledAction';
-				if ( ! is_null( $schedule ) && ! is_a( $schedule, 'ActionScheduler_CanceledSchedule' ) ) {
+				if ( ! is_null( $schedule ) && ! is_a( $schedule, 'ActionScheduler_CanceledSchedule' ) && ! is_a( $schedule, 'ActionScheduler_NullSchedule' ) ) {
 					$schedule = new ActionScheduler_CanceledSchedule( $schedule->get_date() );
 				}
 				break;


### PR DESCRIPTION
Closes #522 

Supersedes #523 

This PR updates the logic for fetching a canceled action to allow the canceled action to have a null schedule.

### Testing

- Activate https://github.com/woocommerce/action-scheduler-disable-default-runner
- Use this snippet to create an async action
```
add_action( 'init', function() {
	as_enqueue_async_action( 'as-async-test'  );
} );
```
- Go to Tools -> Scheduled Actions -> Pending
- Cancel the above action
- Go to the Canceled actions list
- In `master` this produces a fatal error
- In this branch the screen loads and the action has a `0000-00-00 00:00:00` schedule.