### PR TITLE
always check for old cron task before scheduling with context

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -50,16 +50,15 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 
 		add_filter( 'cron_schedules', array( self::instance(), 'add_wp_cron_schedule' ) );
 
+		// Check for and remove any WP Cron hook scheduled by Action Scheduler < 3.0.0, which didn't include the $context param
+		$next_timestamp = wp_next_scheduled( self::WP_CRON_HOOK );
+		if ( $next_timestamp ) {
+			wp_unschedule_event( $next_timestamp, self::WP_CRON_HOOK );
+		}
+
 		$cron_context = array( 'WP Cron' );
 
 		if ( ! wp_next_scheduled( self::WP_CRON_HOOK, $cron_context ) ) {
-
-			// Check for and remove any WP Cron hook scheduled by Action Scheduler < 3.0.0, which didn't include the $context param
-			$next_timestamp = wp_next_scheduled( self::WP_CRON_HOOK );
-			if ( $next_timestamp ) {
-				wp_unschedule_event( $next_timestamp, self::WP_CRON_HOOK );
-			}
-
 			$schedule = apply_filters( 'action_scheduler_run_schedule', self::WP_CRON_SCHEDULE );
 			wp_schedule_event( time(), $schedule, self::WP_CRON_HOOK, $cron_context );
 		}


### PR DESCRIPTION
Closes #528 

This PR changes the logic flow on removing the pre-3.0 cron task to ensure the task is removed on sites where the 3.0 task exists.

### Testing

- Start on the `master` branch
- Install and activate https://wordpress.org/plugins/wp-crontrol/
- Go to Settings -> Cron Schedules -> Manage Cron Events
- Check for two `action_scheduler_run_queue` tasks
<img width="1178" alt="Screen Shot 2020-04-21 at 3 08 05 PM" src="https://user-images.githubusercontent.com/343847/79986471-79111900-8482-11ea-8f6b-78ccf43900c5.png">

- If there is only one task, deactivate AS and activate WooCommerce 3.9.3 to create the second task
- Re-activate AS if necessary and verify two tasks exist
- Switch to this branch 
- Refresh the Crontrol screen
- Only the task with the `WP Cron` context should remain
