### PR TITLE
Deprecate use of shutdown hook

### DIFF
--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -186,7 +186,7 @@ abstract class ActionScheduler {
 	 * @param string $function_name The name of the function being called.
 	 */
 	public static function check_shutdown_hook( $function_name ) {
-		if ( 'shutdown' == current_filter() ) {
+		if ( 'shutdown' === current_filter() ) {
 			$message = sprintf(
 				/* translators: $1: open code tag, $2: function name, $3: close code tag. */
 				__( 'Action Scheduler function %1$s%2$s%3$s should not be used within the WordPress %1$sshutdown%3$s hook.', 'action-scheduler' ),

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -181,6 +181,24 @@ abstract class ActionScheduler {
 	}
 
 	/**
+	 * Issue deprecated warning if an Action Scheduler function is called in the shutdown hook.
+	 *
+	 * @param string $function_name The name of the function being called.
+	 */
+	public static function check_shutdown_hook( $function_name ) {
+		if ( 'shutdown' == current_filter() ) {
+			$message = sprintf(
+				/* translators: $1: open code tag, $2: function name, $3: close code tag. */
+				__( 'Action Scheduler function %1$s%2$s%3$s should not be used within the WordPress %1$sshutdown%3$s hook.', 'action-scheduler' ),
+				'<code>',
+				esc_attr( $function_name ) . '()',
+				'</code>'
+			);
+			_deprecated_hook( 'shutdown', 'Action Scheduler 3.0', 'init', $message );
+		}
+	}
+
+	/**
 	 * Determine if the class is one of our abstract classes.
 	 *
 	 * @since 3.0.0

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -149,7 +149,7 @@ class Controller {
 		add_filter( 'action_scheduler_store_class', array( $this, 'get_store_class' ), 100, 1 );
 		add_filter( 'action_scheduler_logger_class', array( $this, 'get_logger_class' ), 100, 1 );
 		add_action( 'init', array( $this, 'maybe_hook_migration' ) );
-		add_action( 'shutdown', array( $this, 'schedule_migration' ), 0, 0 );
+		add_action( 'init', array( $this, 'schedule_migration' ) );
 
 		// Action Scheduler may be displayed as a Tools screen or WooCommerce > Status administration screen
 		add_action( 'load-tools_page_action-scheduler', array( $this, 'hook_admin_notices' ), 10, 0 );

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -149,7 +149,7 @@ class Controller {
 		add_filter( 'action_scheduler_store_class', array( $this, 'get_store_class' ), 100, 1 );
 		add_filter( 'action_scheduler_logger_class', array( $this, 'get_logger_class' ), 100, 1 );
 		add_action( 'init', array( $this, 'maybe_hook_migration' ) );
-		add_action( 'init', array( $this, 'schedule_migration' ) );
+		add_action( 'wp_loaded', array( $this, 'schedule_migration' ) );
 
 		// Action Scheduler may be displayed as a Tools screen or WooCommerce > Status administration screen
 		add_action( 'load-tools_page_action-scheduler', array( $this, 'hook_admin_notices' ), 10, 0 );

--- a/classes/migration/Scheduler.php
+++ b/classes/migration/Scheduler.php
@@ -83,7 +83,7 @@ class Scheduler {
 		}
 
 		if ( empty( $when ) ) {
-			$when = time();
+			$when = time() + 60;
 		}
 
 		return as_schedule_single_action( $when, self::HOOK, array(), self::GROUP );

--- a/classes/migration/Scheduler.php
+++ b/classes/migration/Scheduler.php
@@ -83,7 +83,7 @@ class Scheduler {
 		}
 
 		if ( empty( $when ) ) {
-			$when = time() + 60;
+			$when = time() + MINUTE_IN_SECONDS;
 		}
 
 		return as_schedule_single_action( $when, self::HOOK, array(), self::GROUP );

--- a/docs/version3-0.md
+++ b/docs/version3-0.md
@@ -2,7 +2,7 @@
 
 ### Do we need to wait for this to be bundled with WooCommerce?
 
-No. Action Scheduler can be run as a standalone plugin. Action Scheduler 3.0 is also part of WooCommerce Subscriptions 3.0, so when updating WooCommerce Subscriptions, Action Scheduler will also be updated.
+No. Action Scheduler can be run as a standalone plugin. Action Scheduler 3.X is also part of WooCommerce 4.0 and WooCommerce Subscriptions 3.0, so when updating WooCommerce or WooCommerce Subscriptions, Action Scheduler will also be updated.
 
 ### Can we safely switch to action scheduler version 3.0 and ditch the custom tables plugin?
 
@@ -35,6 +35,10 @@ The default value for this filter is `1` in versions 3.0.X and `5` in versions 3
 Alternatively, the async queue runner can be disabled while your migration is in process with `add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );`.
 
 Once the migration is complete, these filters should be removed.
+
+### Is it safe to use Action Scheduler function in the WordPress `shutdown` hook.
+
+No, you should avoid calls to Action Scheduler functions in the `shutdown` hook because the `shutdown` hook is still triggered after a fatal error. If this occurs while WordPress is loading, Action Scheduler is in an unknown state.
 
 ### Is there a strong likelihood of migration issues with any of the above?
 

--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,7 @@
  * @return int The action ID.
  */
 function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	return ActionScheduler::factory()->async( $hook, $args, $group );
 }
 
@@ -27,6 +28,7 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
  * @return int The action ID.
  */
 function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	return ActionScheduler::factory()->single( $hook, $args, $timestamp, $group );
 }
 
@@ -42,6 +44,7 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @return int The action ID.
  */
 function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group );
 }
 
@@ -69,6 +72,7 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @return int The action ID.
  */
 function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group );
 }
 
@@ -89,6 +93,7 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
  * @return string|null The scheduled action ID if a scheduled action was found, or null if no matching action found.
  */
 function as_unschedule_action( $hook, $args = array(), $group = '' ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -113,6 +118,7 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
  * @param string $group The group the job is assigned to.
  */
 function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	if ( empty( $args ) ) {
 		if ( ! empty( $hook ) && empty( $group ) ) {
 			ActionScheduler_Store::instance()->cancel_actions_by_hook( $hook );
@@ -144,6 +150,7 @@ function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
  * @return int|bool The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
  */
 function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -196,6 +203,7 @@ function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
  * @return array
  */
 function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
 	$store = ActionScheduler::store();
 	foreach ( array('date', 'modified') as $key ) {
 		if ( isset($args[$key]) ) {

--- a/tests/phpunit/jobstore/ActionScheduler_HybridStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_HybridStore_Test.php
@@ -33,6 +33,7 @@ class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->actionscheduler_actions}" );
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->actionscheduler_logs}" );
 		delete_option( ActionScheduler_HybridStore::DEMARKATION_OPTION );
 	}
 

--- a/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
@@ -23,13 +23,6 @@ class ActionScheduler_DBLogger_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEquals( $message, $entry->get_message() );
 	}
 
-	public function test_null_log_entry() {
-		$logger = ActionScheduler::logger();
-		$entry = $logger->get_entry( 1 );
-		$this->assertEquals( '', $entry->get_action_id() );
-		$this->assertEquals( '', $entry->get_message() );
-	}
-
 	public function test_storage_logs() {
 		$action_id = as_schedule_single_action( time(), __METHOD__ );
 		$logger = ActionScheduler::logger();

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -47,13 +47,6 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 		$this->assertEquals( $message, $entry->get_message() );
 	}
 
-	public function test_null_log_entry() {
-		$logger = ActionScheduler::logger();
-		$entry = $logger->get_entry( 1 );
-		$this->assertEquals( '', $entry->get_action_id() );
-		$this->assertEquals( '', $entry->get_message() );
-	}
-
 	public function test_erroneous_entry_id() {
 		$comment = wp_insert_comment(array(
 			'comment_post_ID' => 1,

--- a/tests/phpunit/migration/Runner_Test.php
+++ b/tests/phpunit/migration/Runner_Test.php
@@ -61,30 +61,30 @@ class Runner_Test extends ActionScheduler_UnitTestCase {
 		$runner->run( 10 );
 
 		// due actions should migrate in the first batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0 ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
 		$this->assertCount( 5, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0 ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
 		$this->assertCount( 10, $remaining );
 
 
 		$runner->run( 10 );
 
 		// pending actions should migrate in the second batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0 ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
 		$this->assertCount( 10, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0 ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
 		$this->assertCount( 5, $remaining );
 
 
 		$runner->run( 10 );
 
 		// completed actions should migrate in the third batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0 ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
 		$this->assertCount( 15, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0 ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
 		$this->assertCount( 0, $remaining );
 
 	}


### PR DESCRIPTION
Closes #536

This PR moves schedule the migration from the `shutdown` hook to the `wp_loaded` hook and schedules it for 1 minute in the future. It updates the unit tests to account for the migration action existing when the unit tests run.

### Testing

- delete the `action_scheduler_migration_status` setting
- Check Scheduled Actions -> Tools -> Pending for the migration hook scheduled to < 60 seconds
- Allow a minute to pass
- Check that the migration action is removed
- Check that the `action_scheduler_migration_status` setting is `complete`