### PR TITLE
update the shutdown check to check for store initialization

### DIFF
--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -11,6 +11,8 @@ abstract class ActionScheduler {
 	private static $plugin_file = '';
 	/** @var ActionScheduler_ActionFactory */
 	private static $factory = NULL;
+	/** @var bool */
+	private static $data_store_initialized = false;
 
 	public static function factory() {
 		if ( !isset(self::$factory) ) {
@@ -170,6 +172,8 @@ abstract class ActionScheduler {
 			}
 		}
 
+		self::$data_store_initialized = true;
+
 		/**
 		 * Handle WP comment cleanup after migration.
 		 */
@@ -181,21 +185,18 @@ abstract class ActionScheduler {
 	}
 
 	/**
-	 * Issue deprecated warning if an Action Scheduler function is called in the shutdown hook.
+	 * Check whether the AS data store has been initialized.
 	 *
 	 * @param string $function_name The name of the function being called.
+	 * @return bool
 	 */
-	public static function check_shutdown_hook( $function_name ) {
-		if ( 'shutdown' === current_filter() ) {
-			$message = sprintf(
-				/* translators: $1: open code tag, $2: function name, $3: close code tag. */
-				__( 'Action Scheduler function %1$s%2$s%3$s should not be used within the WordPress %1$sshutdown%3$s hook.', 'action-scheduler' ),
-				'<code>',
-				esc_attr( $function_name ) . '()',
-				'</code>'
-			);
-			_deprecated_hook( 'shutdown', 'Action Scheduler 3.0', 'init', $message );
+	public static function is_initialized( $function_name ) {
+		if ( ! self::$data_store_initialized ) {
+			$message = sprintf( __( '%s() was called before the Action Scheduler data store was initialized', 'action-scheduler' ), esc_attr( $function_name ) );
+			error_log( $message, E_WARNING );
 		}
+
+		return self::$data_store_initialized;
 	}
 
 	/**
@@ -289,5 +290,15 @@ abstract class ActionScheduler {
 	public static function get_datetime_object( $when = null, $timezone = 'UTC' ) {
 		_deprecated_function( __METHOD__, '2.0', 'wcs_add_months()' );
 		return as_get_datetime_object( $when, $timezone );
+	}
+
+	/**
+	 * Issue deprecated warning if an Action Scheduler function is called in the shutdown hook.
+	 *
+	 * @param string $function_name The name of the function being called.
+	 * @deprecated 3.1.6.
+	 */
+	public static function check_shutdown_hook( $function_name ) {
+		_deprecated_function( __FUNCTION__, '3.1.6' );
 	}
 }

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -187,11 +187,11 @@ abstract class ActionScheduler {
 	/**
 	 * Check whether the AS data store has been initialized.
 	 *
-	 * @param string $function_name The name of the function being called.
+	 * @param string $function_name The name of the function being called. Optional. Default `null`.
 	 * @return bool
 	 */
-	public static function is_initialized( $function_name ) {
-		if ( ! self::$data_store_initialized ) {
+	public static function is_initialized( $function_name = null ) {
+		if ( ! self::$data_store_initialized && ! empty( $function_name ) ) {
 			$message = sprintf( __( '%s() was called before the Action Scheduler data store was initialized', 'action-scheduler' ), esc_attr( $function_name ) );
 			error_log( $message, E_WARNING );
 		}

--- a/functions.php
+++ b/functions.php
@@ -13,7 +13,9 @@
  * @return int The action ID.
  */
 function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
 	return ActionScheduler::factory()->async( $hook, $args, $group );
 }
 
@@ -28,7 +30,9 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
  * @return int The action ID.
  */
 function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
 	return ActionScheduler::factory()->single( $hook, $args, $timestamp, $group );
 }
 
@@ -44,7 +48,9 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @return int The action ID.
  */
 function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
 	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group );
 }
 
@@ -72,7 +78,9 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @return int The action ID.
  */
 function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
 	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group );
 }
 
@@ -93,7 +101,9 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
  * @return string|null The scheduled action ID if a scheduled action was found, or null if no matching action found.
  */
 function as_unschedule_action( $hook, $args = array(), $group = '' ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -118,7 +128,9 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
  * @param string $group The group the job is assigned to.
  */
 function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return;
+	}
 	if ( empty( $args ) ) {
 		if ( ! empty( $hook ) && empty( $group ) ) {
 			ActionScheduler_Store::instance()->cancel_actions_by_hook( $hook );
@@ -150,7 +162,9 @@ function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
  * @return int|bool The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
  */
 function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return false;
+	}
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -203,7 +217,9 @@ function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
  * @return array
  */
 function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
-	ActionScheduler::check_shutdown_hook( __FUNCTION__ );
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return array();
+	}
 	$store = ActionScheduler::store();
 	foreach ( array('date', 'modified') as $key ) {
 		if ( isset($args[$key]) ) {


### PR DESCRIPTION
Closes #545 

This PR changes the `shutdown` hook check introduced in 3.1.5 to an `is_initialized()` check and issue a warning. It updates the `as_*` functions to return a falsey value when the data store is not initialized.

In combination with this PR, plugins using `as_*` functions in the `shutdown` hook should add a `did_action( 'init' )` check to those hooks.

@jessepearson Could you install this PR on your test install to see how many notices you get when using the same setup as in #516 ?

cc @bor0 