### PR TITLE
Fire do_action() inside ActionScheduler_DBStore::delete_action() BEFORE deleting action

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -543,11 +543,13 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	public function delete_action( $action_id ) {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
-		$deleted = $wpdb->delete( $wpdb->actionscheduler_actions, [ 'action_id' => $action_id ], [ '%d' ] );
-		if ( empty( $deleted ) ) {
+		$action = $this->fetch_action( $action_id );
+		if ( is_a( $action, 'ActionScheduler_NullAction' ) ) {
 			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s', 'action-scheduler' ), $action_id ) );
 		}
 		do_action( 'action_scheduler_deleted_action', $action_id );
+
+		$wpdb->delete( $wpdb->actionscheduler_actions, [ 'action_id' => $action_id ], [ '%d' ] );
 	}
 
 	/**


### PR DESCRIPTION
Currently, the `do_action( 'action_scheduler_deleted_action', $action_id );` hook is fired **_after_** the action has been deleted. This makes it impossible to hook into the `action_scheduler_deleted_action`, lookup the action and then do something based on the type of action it is.

It's also inconsistent with `wpPostStore::delete_action()` which fires the `do_action( 'action_scheduler_deleted_action', $action_id );` hook **_before_** performing the deletion. The methods should execute the same code in the same order.

My PR checks to ensure the `$action_id` exists then fires the `action_scheduler_deleted_action` if it does, then finally performs the delete.