### PR TITLE
Add new hook to delete_action() method BEFORE action is deleted

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -543,6 +543,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	public function delete_action( $action_id ) {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
+		do_action( 'action_scheduler_delete_action', $action_id );
 		$deleted = $wpdb->delete( $wpdb->actionscheduler_actions, [ 'action_id' => $action_id ], [ '%d' ] );
 		if ( empty( $deleted ) ) {
 			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s', 'action-scheduler' ), $action_id ) );


### PR DESCRIPTION
This is related to this PR: https://github.com/woocommerce/action-scheduler/pull/559

The `ActionScheduler_DBStore::delete_action()` method contains this hook:

```php
do_action( 'action_scheduler_deleted_action', $action_id );
```

The problem is that hook is fired **_after_** the action has been deleted therefore making the `$action_id` argument essentially useless because there's nothing you can do with it... the record with that `$action_id` has already been deleted from the database.

I've added a new hook (as per @rrennick's [suggestion](https://github.com/woocommerce/action-scheduler/pull/559#issuecomment-633981875)) to fire **_before_** the action is deleted from the database.

This allows listeners of the new `action_scheduler_delete_action` hook  to actually do something with the `$action_id` value  before it is permanently removed from the database.

FWIW, my use case is this: I use ActionScheduler to schedule regular and important actions. But there's always a risk of a user deleting the scheduled action from the Scheduled Actions Admin interface. By hooking into the new `action_scheduler_delete_action` hook, I can listen for my own plugin's actions getting deleted and either notify the user or simply reschedule the action. 

Thanks for such a great plugin! IMO, ActionScheduler should be in core!