### PR TITLE
support decimal gmt_offset

### DIFF
--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -18,17 +18,6 @@ class ActionScheduler_DateTime extends DateTime {
 	protected $utcOffset = 0;
 
 	/**
-	 * Get the unix timestamp of the current object.
-	 *
-	 * Missing in PHP 5.2 so just here so it can be supported consistently.
-	 *
-	 * @return int
-	 */
-	public function getTimestamp() {
-		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
-	}
-
-	/**
 	 * Set the UTC offset.
 	 *
 	 * This represents a fixed offset instead of a timezone setting.

--- a/classes/abstracts/ActionScheduler_TimezoneHelper.php
+++ b/classes/abstracts/ActionScheduler_TimezoneHelper.php
@@ -22,7 +22,9 @@ abstract class ActionScheduler_TimezoneHelper {
 			$date = as_get_datetime_object( $date->format( 'U' ) );
 		}
 
-		if ( get_option( 'timezone_string' ) ) {
+		if ( function_exists( 'wp_timezone_string' ) ) {
+			$date->setTimezone( new DateTimeZone( wp_timezone_string() ) );
+		} elseif ( get_option( 'timezone_string' ) ) {
 			$date->setTimezone( new DateTimeZone( self::get_local_timezone_string() ) );
 		} else {
 			$date->setUtcOffset( self::get_local_timezone_offset() );
@@ -52,13 +54,13 @@ abstract class ActionScheduler_TimezoneHelper {
 		}
 
 		// Get UTC offset, if it isn't set then return UTC.
-		$utc_offset = intval( get_option( 'gmt_offset', 0 ) );
-		if ( 0 === $utc_offset ) {
+		$utc_offset = get_option( 'gmt_offset', 0 );
+		if ( ! is_numeric( $utc_offset ) || 0 === $utc_offset ) {
 			return 'UTC';
 		}
 
 		// Adjust UTC offset from hours to seconds.
-		$utc_offset *= 3600;
+		$utc_offset = (int) ( $utc_offset * 3600 );
 
 		// Attempt to guess the timezone string from the UTC offset.
 		$timezone = timezone_name_from_abbr( '', $utc_offset );

--- a/classes/abstracts/ActionScheduler_TimezoneHelper.php
+++ b/classes/abstracts/ActionScheduler_TimezoneHelper.php
@@ -54,8 +54,8 @@ abstract class ActionScheduler_TimezoneHelper {
 		}
 
 		// Get UTC offset, if it isn't set then return UTC.
-		$utc_offset = get_option( 'gmt_offset', 0 );
-		if ( ! is_numeric( $utc_offset ) || 0 === $utc_offset ) {
+		$utc_offset = float( get_option( 'gmt_offset', 0 ) );
+		if ( ! is_numeric( $utc_offset ) || 0.0 === $utc_offset ) {
 			return 'UTC';
 		}
 


### PR DESCRIPTION
This PR adds support for timezone offsets that are partial hours (eg. St. Johns, NFLD is UTC -3:30 on non-DST time).

I hacked together a bit of code to test this.

```
function as_filter_gmt_offset() {
	global $_timezone;
	return $_timezone;
}

add_action( 'init', function() {
	// access protected function
	class AS_TZH extends ActionScheduler_TimezoneHelper {
		public static function get_local_timezone() {
			return self::get_local_timezone_string();
		}
	}

	global $_timezone;
	$timezones = range( -11.5, 12, 0.5 );
	add_filter( 'pre_option_gmt_offset', 'as_filter_gmt_offset' );
	// ensure the timezone string setting is empty
	add_filter( 'pre_option_timezone_string', '__return_empty_string' );
	foreach ( $timezones as $zone ) {
		$_timezone = $zone;
		error_log( $zone . ': ' . AS_TZH::get_local_timezone() );
	}
	remove_filter( 'pre_option_gmt_offset', 'as_filter_gmt_offset' );
	remove_filter( 'pre_option_timezone_string', '__return_empty_string' );
} );
```

This produced

```
[26-May-2020 19:20:03 UTC] -11.5: 
[26-May-2020 19:20:03 UTC] -11: America/Adak
[26-May-2020 19:20:03 UTC] -10.5: Pacific/Honolulu
[26-May-2020 19:20:03 UTC] -10: America/Anchorage
[26-May-2020 19:20:03 UTC] -9.5: 
[26-May-2020 19:20:03 UTC] -9: America/Anchorage
[26-May-2020 19:20:03 UTC] -8.5: 
[26-May-2020 19:20:03 UTC] -8: America/Los_Angeles
[26-May-2020 19:20:03 UTC] -7.5: 
[26-May-2020 19:20:03 UTC] -7: America/Denver
[26-May-2020 19:20:03 UTC] -6.5: 
[26-May-2020 19:20:03 UTC] -6: America/Chicago
[26-May-2020 19:20:03 UTC] -5.5: 
[26-May-2020 19:20:03 UTC] -5: America/Havana
[26-May-2020 19:20:03 UTC] -4.5: 
[26-May-2020 19:20:03 UTC] -4: America/Anguilla
[26-May-2020 19:20:03 UTC] -3.5: America/St_Johns
[26-May-2020 19:20:03 UTC] -3: 
[26-May-2020 19:20:03 UTC] -2.5: 
[26-May-2020 19:20:03 UTC] -2: 
[26-May-2020 19:20:03 UTC] -1.5: 
[26-May-2020 19:20:03 UTC] -1: 
[26-May-2020 19:20:03 UTC] -0.5: 
[26-May-2020 19:20:03 UTC] 0: Africa/Abidjan
[26-May-2020 19:20:03 UTC] 0.5: 
[26-May-2020 19:20:03 UTC] 1: Europe/London
[26-May-2020 19:20:03 UTC] 1.5: Africa/Johannesburg
[26-May-2020 19:20:03 UTC] 2: Africa/Khartoum
[26-May-2020 19:20:03 UTC] 2.5: 
[26-May-2020 19:20:03 UTC] 3: Africa/Khartoum
[26-May-2020 19:20:03 UTC] 3.5: 
[26-May-2020 19:20:03 UTC] 4: Europe/Moscow
[26-May-2020 19:20:03 UTC] 4.5: 
[26-May-2020 19:20:03 UTC] 5: Asia/Karachi
[26-May-2020 19:20:03 UTC] 5.5: Asia/Calcutta
[26-May-2020 19:20:03 UTC] 6: 
[26-May-2020 19:20:03 UTC] 6.5: 
[26-May-2020 19:20:03 UTC] 7: Asia/Jakarta
[26-May-2020 19:20:03 UTC] 7.5: 
[26-May-2020 19:20:03 UTC] 8: Australia/Perth
[26-May-2020 19:20:03 UTC] 8.5: Asia/Hong_Kong
[26-May-2020 19:20:03 UTC] 9: Asia/Tokyo
[26-May-2020 19:20:03 UTC] 9.5: Australia/Adelaide
[26-May-2020 19:20:03 UTC] 10: Australia/Melbourne
[26-May-2020 19:20:03 UTC] 10.5: 
[26-May-2020 19:20:03 UTC] 11: 
[26-May-2020 19:20:03 UTC] 11.5: Pacific/Auckland
[26-May-2020 19:20:03 UTC] 12: Pacific/Auckland
```

@menakas Do those look correct?