### PR TITLE
Fix #589: Add check that function add_action() exists

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -27,6 +27,11 @@
 
 if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) ) {
 
+	if ( ! function_exists( 'add_action' ) ) {
+		// We are running outside of the context of WordPress.
+		return;
+	}
+
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -25,12 +25,7 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) ) {
-
-	if ( ! function_exists( 'add_action' ) ) {
-		// We are running outside of the context of WordPress.
-		return;
-	}
+if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) && function_exists( 'add_action' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );


### PR DESCRIPTION
By checking that the function add_action() exists, before we call it, we
can avoid throwing a fatal error when a PHP tool is run (e.g. phpcs)
even if we are loading `action-scheduler.php` via Composer's autoload.

See #303
See #589 