### PR TITLE
Change relative include paths to absolute include paths

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -26,9 +26,10 @@
  */
 
 if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) ) {
+	$dir = __DIR__ . DIRECTORY_SEPARATOR;
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
-		require_once( dirname( __FILE__ ) . 'classes/ActionScheduler_Versions.php' );
+		require_once( $dir . 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
@@ -40,7 +41,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) ) {
 	}
 
 	function action_scheduler_initialize_3_dot_1_dot_6() {
-		require_once( dirname( __FILE__ ) . 'classes/abstracts/ActionScheduler.php' );
+		require_once( $dir . 'classes/abstracts/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}
 

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -26,7 +26,7 @@
  */
 
 if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) ) {
-	$dir = __DIR__ . DIRECTORY_SEPARATOR;
+	$dir = __DIR__ . '/';
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( $dir . 'classes/ActionScheduler_Versions.php' );

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -28,7 +28,7 @@
 if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) && function_exists( 'add_action' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
-		require_once( $dir . 'classes/ActionScheduler_Versions.php' );
+		require_once( __DIR__ . '/classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
@@ -40,7 +40,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) && function_
 	}
 
 	function action_scheduler_initialize_3_dot_1_dot_6() {
-		require_once( $dir . 'classes/abstracts/ActionScheduler.php' );
+		require_once( __DIR__ . '/classes/abstracts/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}
 

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -28,7 +28,7 @@
 if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
-		require_once( 'classes/ActionScheduler_Versions.php' );
+		require_once( dirname( __FILE__ ) . 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
@@ -40,7 +40,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_1_dot_6' ) ) {
 	}
 
 	function action_scheduler_initialize_3_dot_1_dot_6() {
-		require_once( 'classes/abstracts/ActionScheduler.php' );
+		require_once( dirname( __FILE__ ) . 'classes/abstracts/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}
 

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -67,7 +67,7 @@ abstract class ActionScheduler {
 	}
 
 	public static function autoload( $class ) {
-		$d           = DIRECTORY_SEPARATOR;
+		$d           = '/';
 		$classes_dir = self::plugin_path( 'classes' . $d );
 		$separator   = strrpos( $class, '\\' );
 		if ( false !== $separator ) {
@@ -119,7 +119,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( file_exists( "{$dir}{$class}.php" ) ) {
-			include( $dir . "{$class}.php" );
+			include( $dir . $class . '.php' );
 			return;
 		}
 	}

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -119,7 +119,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( file_exists( "{$dir}{$class}.php" ) ) {
-			include( "{$dir}{$class}.php" );
+			include( dirname( __FILE__ ) . "{$dir}{$class}.php" );
 			return;
 		}
 	}

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -119,7 +119,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( file_exists( "{$dir}{$class}.php" ) ) {
-			include( dirname( __FILE__ ) . "{$dir}{$class}.php" );
+			include( __DIR__ . DIRECTORY_SEPARATOR . "{$dir}{$class}.php" );
 			return;
 		}
 	}

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -119,7 +119,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( file_exists( "{$dir}{$class}.php" ) ) {
-			include( "{$dir}{$class}.php" );
+			include( $dir . "{$class}.php" );
 			return;
 		}
 	}

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -119,7 +119,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( file_exists( "{$dir}{$class}.php" ) ) {
-			include( __DIR__ . DIRECTORY_SEPARATOR . "{$dir}{$class}.php" );
+			include( "{$dir}{$class}.php" );
 			return;
 		}
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,10 +25,10 @@ if( false !== getenv( 'WP_TESTS_DIR' ) ) {
 }
 
 if ( class_exists( 'PHPUnit\Framework\TestResult' ) ) { // PHPUnit 6.0 or newer
-	include_once('ActionScheduler_UnitTestCase.php');
+	include_once( __DIR__ . '/ActionScheduler_UnitTestCase.php' );
 } else {
-	include_once('phpunit/deprecated/ActionScheduler_UnitTestCase.php');
+	include_once( __DIR__ . '/phpunit/deprecated/ActionScheduler_UnitTestCase.php' );
 }
 
-include_once('phpunit/ActionScheduler_Mocker.php');
-include_once('phpunit/ActionScheduler_Mock_Async_Request_QueueRunner.php');
+include_once( __DIR__ . '/phpunit/ActionScheduler_Mocker.php' );
+include_once( __DIR__ . '/phpunit/ActionScheduler_Mock_Async_Request_QueueRunner.php' );


### PR DESCRIPTION
Relates to woocommerce/woocommerce#27269 and woocommerce/woocommerce#27433

## Overview
Relative include paths in PHP can break, when server is running opcache. See here about vulnerability details.

WordPress.com deploy system refuses to include WooCommerce, because of that issue - for more context, see here - internal a8c discussion This PR changes the relative include paths to absolute include pathss.

