### PR TITLE
add WP CLI version subcommand

### DIFF
--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -87,6 +87,27 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Print Action Scheduler version
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--which]
+	 * : The path of the active version.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 *
+	 * @subcommand version
+	 */
+	public function version( $args, $assoc_args ) {
+		$message = ActionScheduler_Versions::instance()->latest_version();
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'which', false ) ) {
+			$message .= ':' . ActionScheduler::plugin_path( '' );
+		}
+		WP_CLI::line( $message );
+	}
+
+	/**
 	 * Print WP CLI message about how many actions are about to be processed.
 	 *
 	 * @author Jeremy Pry


### PR DESCRIPTION
This PR supersedes #271. 

It adds a WP CLI `version` subcommand including a `which` flag. The WooCommerce system status page includes both the active version and full path of the active instance of Action Scheduler. This PR adds the availability of these values to WP CLI.

### Testing instructions

1- `wp help action-scheduler` should output
```
SYNOPSIS

  wp action-scheduler <command>

SUBCOMMANDS

  run          Run the Action Scheduler
  version      Print Action Scheduler version
```
2- `wp help action-scheduler version` should output
```
SYNOPSIS

  wp action-scheduler version [--which]
```
3- `wp action-scheduler version` should output `3.1.6`
4- `wp action-scheduler version --which` should output 
```
3.1.6:/var/www/html/wp-content/plugins/action-scheduler
```
