### PR TITLE
Update the Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,43 +3,42 @@
 # Tell Travis CI we're using PHP
 language: php
 
-# We nee to use Precise, not Trusty, to test against PHP 5.3, see https://github.com/travis-ci/travis-ci/issues/8219
-dist: precise
+dist: trusty
 
 # Versions of PHP to test against
 php:
-    - "5.3"
     - "5.6"
     - "7.0"
     - "7.1"
     - "7.2"
     - "7.3"
+    - "7.4"
 
 # Specify versions of WordPress to test against
 # WP_VERSION = WordPress version number (use "master" for SVN trunk)
 # WP_MULTISITE = whether to test multisite (use either "0" or "1")
 env:
+    - WP_VERSION=5.5 WP_MULTISITE=0
+    - WP_VERSION=5.4 WP_MULTISITE=0
     - WP_VERSION=5.3 WP_MULTISITE=0
-    - WP_VERSION=5.2 WP_MULTISITE=0
-    - WP_VERSION=5.1 WP_MULTISITE=0
+    - WP_VERSION=5.5 WP_MULTISITE=1
+    - WP_VERSION=5.4 WP_MULTISITE=1
     - WP_VERSION=5.3 WP_MULTISITE=1
-    - WP_VERSION=5.2 WP_MULTISITE=1
-    - WP_VERSION=5.1 WP_MULTISITE=1
 
-# WordPress 5.3 requires PHP 5.6. Exclude WP 5.3 + PHP 5.3
+# WordPress 5.5 recommends PHP 7.0. Exclude WP 5.5 + PHP 5.6
 jobs:
   exclude:
-    - php: "5.3"
-      env: WP_VERSION=5.3 WP_MULTISITE=0
-    - php: "5.3"
-      env: WP_VERSION=5.3 WP_MULTISITE=1
+    - php: "5.6"
+      env: WP_VERSION=5.5 WP_MULTISITE=0
+    - php: "5.6"
+      env: WP_VERSION=5.5 WP_MULTISITE=1
 
 # Grab the setup script and execute
 before_script:
     - source tests/travis/setup.sh $TRAVIS_PHP_VERSION
 
 script:
- - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]] && [[ "$WP_VERSION" == "5.3" ]] && [[ "$WP_MULTISITE" == "0" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]; then phpunit --configuration tests/phpunit.xml.dist --coverage-clover clover.xml; else phpunit --configuration tests/phpunit.xml.dist; fi
+ - if [[ "$TRAVIS_PHP_VERSION" == "7.4" ]] && [[ "$WP_VERSION" == "5.5" ]] && [[ "$WP_MULTISITE" == "0" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]; then phpunit --configuration tests/phpunit.xml.dist --coverage-clover clover.xml; else phpunit --configuration tests/phpunit.xml.dist; fi
 
 after_script:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
     - "7.1"
     - "7.2"
     - "7.3"
-    - "7.4"
 
 # Specify versions of WordPress to test against
 # WP_VERSION = WordPress version number (use "master" for SVN trunk)
@@ -38,7 +37,7 @@ before_script:
     - source tests/travis/setup.sh $TRAVIS_PHP_VERSION
 
 script:
- - if [[ "$TRAVIS_PHP_VERSION" == "7.4" ]] && [[ "$WP_VERSION" == "5.5" ]] && [[ "$WP_MULTISITE" == "0" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]; then phpunit --configuration tests/phpunit.xml.dist --coverage-clover clover.xml; else phpunit --configuration tests/phpunit.xml.dist; fi
+ - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]] && [[ "$WP_VERSION" == "5.5" ]] && [[ "$WP_MULTISITE" == "0" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]; then phpunit --configuration tests/phpunit.xml.dist --coverage-clover clover.xml; else phpunit --configuration tests/phpunit.xml.dist; fi
 
 after_script:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "minimum-stability": "dev",
   "require": {},
   "require-dev": {
-    "phpunit/phpunit": "^5.6",
+    "phpunit/phpunit": "^6.5",
     "wp-cli/wp-cli": "~1.5.1",
     "woocommerce/woocommerce-sniffs": "0.0.8"
   },


### PR DESCRIPTION
This PR updates the WP test versions in the test matrix. PHP 5.3 isn't supported in any of the tested WP versions so it was removed.

The unit test mock functions were throwing deprecated notices under PHP 7.4. That will need to be investigated and resolved before PHP 7.4 can be added to the matrix.