### PR TITLE
[PHP 8.0] Only pass action arg values through to do_action_ref_array()

### DIFF
--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -19,7 +19,7 @@ class ActionScheduler_Action {
 	}
 
 	public function execute() {
-		return do_action_ref_array($this->get_hook(), $this->get_args());
+		return do_action_ref_array( $this->get_hook(), array_values( $this->get_args() ) );
 	}
 
 	/**


### PR DESCRIPTION
In PHP 8.0, calling `call_user_func_array` with an array of args with string keys will match the array keys to the callback's function parameter named arguments. Calling `do_action_ref_array()` eventually leads to a `call_user_func_array()` call and so we cannot pass string keys otherwise fatals will occur if there are callbacks attached with parameters with names different to the key.

eg 

```php
as_schedule_single_action( $time, $hook, array( 'order_id' => 123 ) );

add_action( $hook, 'xyz' );

function xyz( $order ) { // Fatal error

function xyz( $order_id ) { // Accepted
```

See:
- https://wiki.php.net/rfc/named_params/#call_user_func_and_friends
- pb0GrA-Yc-p2#comment-1510