### PR TITLE
Allow to query actions for multiple status on DBStore supporting arra…

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -311,8 +311,21 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		if ( $query[ 'status' ] ) {
-			$sql          .= " AND a.status=%s";
-			$sql_params[] = $query[ 'status' ];
+			if( is_array( $query[ 'status' ] ) ) {
+				$sql  .= " AND a.status IN (";
+				$last = end( $query[ 'status' ] );
+				foreach( $query[ 'status' ] as $status ) {
+					$sql .= "%s";
+					if( $status != $last ) {
+						$sql .= ",";
+					}
+					$sql_params[] = $status;
+				}
+				$sql .= ")";
+			} else {
+				$sql          .= " AND a.status=%s";
+				$sql_params[] = $query[ 'status' ];
+			}
 		}
 
 		if ( $query[ 'date' ] instanceof \DateTime ) {


### PR DESCRIPTION
…y of values

closes #643

## Use cases

### Using 1 status (current default)

```php
$args = array (
	'per_page'	=> -1,
	'hook'		=> 'some_hook',
	'status'	=> ActionScheduler_Store::STATUS_FAILED,
);

$_actions = as_get_scheduled_actions( $args );
```

### Using multiple status

```php
$args = array (
	'per_page'	=> -1,
	'hook'		=> 'some_hook',
	'status'	=> array(
		ActionScheduler_Store::STATUS_PENDING,
		ActionScheduler_Store::STATUS_FAILED,
	),
);

$_actions = as_get_scheduled_actions( $args );
```