### PR TITLE
Improve test_migration_is_scheduled

### DIFF
--- a/tests/phpunit/migration/Scheduler_Test.php
+++ b/tests/phpunit/migration/Scheduler_Test.php
@@ -41,7 +41,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		$scheduler->schedule_migration();
 		$this->assertTrue(
 			$scheduler->is_migration_scheduled(),
-			'Migration is scheduled only after is_mmigration_scheduled() has been called.'
+			'Migration is scheduled only after schedule_migration() has been called.'
 		);
 	}
 

--- a/tests/phpunit/migration/Scheduler_Test.php
+++ b/tests/phpunit/migration/Scheduler_Test.php
@@ -29,8 +29,20 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_migration_is_scheduled() {
+		// Clear the any existing migration hooks that have already been setup.
+		as_unschedule_all_actions( Scheduler::HOOK );
+
 		$scheduler = new Scheduler();
-		$this->assertTrue( $scheduler->is_migration_scheduled() );
+		$this->assertFalse(
+			$scheduler->is_migration_scheduled(),
+			'Migration is not automatically scheduled when a new ' . Scheduler::class . ' instance is created.'
+		);
+
+		$scheduler->schedule_migration();
+		$this->assertTrue(
+			$scheduler->is_migration_scheduled(),
+			'Migration is scheduled only after it has explicitly been scheduled.'
+		);
 	}
 
 	public function test_scheduler_runs_migration() {

--- a/tests/phpunit/migration/Scheduler_Test.php
+++ b/tests/phpunit/migration/Scheduler_Test.php
@@ -41,7 +41,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		$scheduler->schedule_migration();
 		$this->assertTrue(
 			$scheduler->is_migration_scheduled(),
-			'Migration is scheduled only after it has explicitly been scheduled.'
+			'Migration is scheduled only after is_mmigration_scheduled() has been called.'
 		);
 	}
 


### PR DESCRIPTION
Improves [Scheduler_Test::test_migration_is_scheduled()](https://github.com/woocommerce/action-scheduler/blob/3.1.6/tests/phpunit/migration/Scheduler_Test.php#L31-L34) so that it passes consistently, and better describes how migration is triggered.

---

:test_tube: **How were we testing?** → A new instance of [Action_Scheduler\Migration\Scheduler](https://github.com/woocommerce/action-scheduler/blob/3.1.6/classes/migration/Scheduler.php) was being created and we then confirmed that—immediately after instantiation—a migration action had been scheduled. If we look at the class, though, we can see that a call to the [schedule_migration()](https://github.com/woocommerce/action-scheduler/blob/3.1.6/classes/migration/Scheduler.php#L71-L90) method should be needed for this to happen (so, the test shouldn't really have been passing: by itself, creating the object isn't enough).

:timer_clock: **Consistency** → Locally, I found this test consistently failed (which makes sense, given the above note) whereas within Travis CI it would pass [(here is one such example of all tests passing)](https://travis-ci.com/github/woocommerce/action-scheduler/builds/217980060). I suspect the reason the test mostly passed within Travis is that A) the order in which tests run is not guaranteed and B) other tests were running earlier, and they were setting up the migration action (and that specific piece of global state was not being cleared between tests).

:hammer_and_wrench: **Change** → I modified the test to clear the relevant global state and added an assertion to show that the migration is _not_ automatically scheduled.

---

:memo: **Other notes** → In trying to figure out why tests might have been executing in a different order I did also come to realize that, as currently configured, Travis is using PhpUnit 5 (not PhpUnit 7 as locally/as defined in composer.json) and also executes with unsupported PHP runtimes. Will plan to do some follow-up work to address those things.