### PR TITLE
Add secondary scheduled date checks when claiming actions (DBStore) | #634

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -15,7 +15,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * This is used in preference to passing the same information as a method param
 	 * for backwards-compatibility reasons.
 	 *
-	 * @var ?DateTime
+	 * @var DateTime|null
 	 */
 	private $claim_before_date = null;
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1,7 +1,5 @@
 <?php
 
-use DateTime;
-
 /**
  * Class ActionScheduler_DBStore
  *

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -610,7 +610,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$this->claim_before_date = $before_date;
 		$this->claim_actions( $claim_id, $max_actions, $before_date, $hooks, $group );
 		$action_ids = $this->find_actions_by_claim_id( $claim_id );
-		unset( $this->claim_before_date );
+		$this->claim_before_date = null;
 
 		return new ActionScheduler_ActionClaim( $claim_id, $action_ids );
 	}

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -297,11 +297,11 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 	 * @see https://github.com/woocommerce/action-scheduler/issues/634
 	 */
 	public function test_claim_filters_out_unexpected_future_actions() {
-		$group      = __METHOD__;
-		$store      = new ActionScheduler_DBStore();
+		$group = __METHOD__;
+		$store = new ActionScheduler_DBStore();
 
 		// Create 4 actions: 2 that are already due (-3hrs and -1hrs) and 2 that are not yet due (+1hr and +3hrs).
-		for ($i = -3; $i <= 3; $i += 2 ) {
+		for ( $i = -3; $i <= 3; $i += 2 ) {
 			$schedule     = new ActionScheduler_SimpleSchedule( as_get_datetime_object( $i . ' hours' ) );
 			$action_ids[] = $store->save_action( new ActionScheduler_Action( 'test_' . $i, array(), $schedule, $group ) );
 		}

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -286,6 +286,54 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEqualSets( array_slice( $created_actions_by_hook[ $unique_hook_two ][ $unique_group_two ], 3, 3 ), $claim->get_actions() );
 	}
 
+	/**
+	 * The query used to claim actions explicitly ignores future pending actions, but it
+	 * is still possible under unusual conditions (such as if MySQL runs out of temporary
+	 * storage space) for such actions to be returned.
+	 *
+	 * When this happens, we still expect the store to filter them out, otherwise there is
+	 * a risk that actions will be unexpectedly processed ahead of time.
+	 *
+	 * @see https://github.com/woocommerce/action-scheduler/issues/634
+	 */
+	public function test_claim_filters_out_unexpected_future_actions() {
+		$group      = __METHOD__;
+		$store      = new ActionScheduler_DBStore();
+
+		// Create 4 actions: 2 that are already due (-3hrs and -1hrs) and 2 that are not yet due (+1hr and +3hrs).
+		for ($i = -3; $i <= 3; $i += 2 ) {
+			$schedule     = new ActionScheduler_SimpleSchedule( as_get_datetime_object( $i . ' hours' ) );
+			$action_ids[] = $store->save_action( new ActionScheduler_Action( 'test_' . $i, array(), $schedule, $group ) );
+		}
+
+		// This callback is used to simulate the unusual conditions whereby MySQL might unexpectedly return future,
+		// actions, contrary to the conditions used by the store object when staking its claim.
+		$simulate_unexpected_db_behavior = static function( $sql ) use ( $action_ids ) {
+			global $wpdb;
+
+			// Look out for the claim update query, ignore all others.
+			if (
+				0 !== strpos( $sql, "UPDATE $wpdb->actionscheduler_actions" )
+				|| ! preg_match( "/claim_id = 0 AND scheduled_date_gmt <= '([0-9:\-\s]{19})'/", $sql, $matches )
+				|| count( $matches ) !== 2
+			) {
+				return $sql;
+			}
+
+			// Now modify the query, forcing it to also return the future actions we created.
+			return str_replace( $matches[1], as_get_datetime_object( '+4 hours' )->format( 'Y-m-d H:i:s' ), $sql );
+		};
+
+		add_filter( 'query', $simulate_unexpected_db_behavior );
+		$claim = $store->stake_claim( 10, null, array(), $group );
+		$claimed_actions = $claim->get_actions();
+		$this->assertCount( 2, $claimed_actions );
+
+		// Cleanup.
+		remove_filter( 'query', $simulate_unexpected_db_behavior );
+		$store->release_claim( $claim );
+	}
+
 	public function test_duplicate_claim() {
 		$created_actions = [];
 		$store           = new ActionScheduler_DBStore();

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -306,7 +306,7 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 			$action_ids[] = $store->save_action( new ActionScheduler_Action( 'test_' . $i, array(), $schedule, $group ) );
 		}
 
-		// This callback is used to simulate the unusual conditions whereby MySQL might unexpectedly return future,
+		// This callback is used to simulate the unusual conditions whereby MySQL might unexpectedly return future
 		// actions, contrary to the conditions used by the store object when staking its claim.
 		$simulate_unexpected_db_behavior = static function( $sql ) use ( $action_ids ) {
 			global $wpdb;


### PR DESCRIPTION
:ticket: [#634 → Double check action scheduled date in case they're processing too early](https://github.com/woocommerce/action-scheduler/issues/634)

Closes #634

### :confounded: The Problem

We can broadly divide pending scheduled actions into two categories:

- Those that are due now.
- Those that are not due until some future point in time.

When the Queue Runner claims a set of actions it does so with a query that is designed to ignore those actions that are not yet due, which makes sense (as a commenter in the linked issue noted, we want to _make sure the scheduled date is not in the future before running it)._

However, there's a body of reported evidence suggesting that—under unusual conditions, such as if MySQL finds it is out of disk space—the `WHERE` conditions we use to enforce this are seemingly not respected. To combat this, we need an extra set of checks that run at PHP-level.

### :hammer_and_wrench: This Changeset

We were already specifying a `$before_date` when claiming actions (defaulting to 'now') ... with this change, we also test _at PHP-level_ after fetching the individual actions to make sure that the `$before_date` condition was respected (we don't just rely on MySQL).

This way, besides adding extra safety for common cases, if some custom code wishes to stake a claim that explicitly includes future pending actions (by specifying a `$before_date` in the future) then that custom code should still function as previously.

### :memo: Some Notes

* I have focused on the `DBStore` in this PR. Let's confirm we're happy with this approach/refine and adjust as needed, and I can follow-up with a corresponding change for the `wpPostStore`.
* Try as I might, I could not actually replicate the problem so I've done my best to simulate it in the test suite by intercepting the [claim staking query](https://github.com/woocommerce/action-scheduler/blob/3.1.6/classes/data-stores/ActionScheduler_DBStore.php#L637-L646) and modifying it so that it also claims future actions. My thinking is this replicates a situation where the DBStore builds a query that should ignore actions that are not yet due, but where MySQL returns them anyway).