### PR TITLE
Add secondary scheduled date checks when claiming actions (wpPostStore) | #634

### DIFF
--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -308,7 +308,7 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 
 		// This callback is used to simulate the unusual conditions whereby MySQL might unexpectedly return future
 		// actions, contrary to the conditions used by the store object when staking its claim.
-		$simulate_unexpected_db_behavior = static function( $sql ) use ( $action_ids ) {
+		$simulate_unexpected_db_behavior = function( $sql ) use ( $action_ids ) {
 			global $wpdb;
 
 			// Look out for the claim update query, ignore all others.

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -434,7 +434,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 		// This callback is used to simulate the unusual conditions whereby MySQL might unexpectedly return future
 		// actions, contrary to the conditions used by the store object when staking its claim.
-		$simulate_unexpected_db_behavior = static function( $sql ) use ( $action_ids ) {
+		$simulate_unexpected_db_behavior = function( $sql ) use ( $action_ids ) {
 			global $wpdb;
 
 			$post_type = ActionScheduler_wpPostStore::POST_TYPE;

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -165,7 +165,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$store->release_claim( $claim );
 
 		// Make sure the 3rd instance of the cron action is scheduled for 24 hours from now, as the action was run early, ahead of schedule
-		$runner->process_action( $action_id );
+		$runner->process_action( $fetched_action_id );
 		$date = as_get_datetime_object( '+1 day' );
 
 		$claim = $store->stake_claim( 10, $date );


### PR DESCRIPTION
:bulb: **This is essentially a replica of [a previous PR](https://github.com/woocommerce/action-scheduler/pull/668)** → please refer back to that for a description of the problem and how we're solving it. In this PR, I'm basically taking the same approach used for the `DBStore`, but have ported it to the `wpPostStore`. Closes #634.

#### Changelog

> Fix - Prevents pending actions that are not yet due from being claimed prematurely.