### PR TITLE
Correct oversight in test_next_instance_of_interval_action

### DIFF
--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -165,7 +165,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$store->release_claim( $claim );
 
 		// Make sure the 3rd instance of the cron action is scheduled for 24 hours from now, as the action was run early, ahead of schedule
-		$runner->process_action( $action_id );
+		$runner->process_action( $fetched_action_id );
 		$date = as_get_datetime_object( '+1 day' );
 
 		$claim = $store->stake_claim( 10, $date );


### PR DESCRIPTION
Addresses what I believe is a bit of an oversight in [test_next_instance_of_interval_action](https://github.com/woocommerce/action-scheduler/blob/3.1.6/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php#L128-L181).

:hammer_and_wrench:  Within this method, `$action_id` represents the first individual action in a series that is set to recur every 24hrs. We then [run the queue](https://github.com/woocommerce/action-scheduler/compare/fix/634-date-checks--wp-post-store...fix/634-date-checks--wp-post-store--tests?expand=1#diff-2fd59945ebe22bbea56dd19195fec979d5ee027dc705ac6b6af4eb01defad288R151) and place the ID of the [next scheduled action](https://github.com/woocommerce/action-scheduler/compare/fix/634-date-checks--wp-post-store...fix/634-date-checks--wp-post-store--tests?expand=1#diff-2fd59945ebe22bbea56dd19195fec979d5ee027dc705ac6b6af4eb01defad288L158) inside `$fetched_action_id`. Later, when we reach the [line that I changed](https://github.com/woocommerce/action-scheduler/compare/fix/634-date-checks--wp-post-store...fix/634-date-checks--wp-post-store--tests?expand=1#diff-2fd59945ebe22bbea56dd19195fec979d5ee027dc705ac6b6af4eb01defad288L168-R168), you can see that we have been trying to re-run `$action_id`, despite it already having run. 

:bulb: I came across this via a failing build for [PR 671](https://github.com/woocommerce/action-scheduler/pull/671) [(see this note)](https://github.com/woocommerce/action-scheduler/pull/671#issuecomment-790186965). The problem only showed up under PHP 5.3, and only for WordPress 5.1, and so this also meant running the tests under PhpUnit 4.8. Though it's a small change, I'm calling it out in its own PR just to get fresh eyes on it (as really it is a distinct problem from what I was addressing in [PR 671](https://github.com/woocommerce/action-scheduler/pull/671) itself).


https://travis-ci.com/github/woocommerce/action-scheduler/builds/219381709