### PR TITLE
fixes #664 by replacing __ with esc_html__

### DIFF
--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -139,7 +139,7 @@ class Controller {
 	 * Show a dashboard notice that migration is in progress.
 	 */
 	public function display_migration_notice() {
-		printf( '<div class="notice notice-warning"><p>%s</p></div>', __( 'Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ) );
+		printf( '<div class="notice notice-warning"><p>%s</p></div>', esc_html__( 'Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses issue #664 by adding the `esc_html__` escaping function instead of `__`.