### PR TITLE
Use better upper bound for scheduled_date_gmt when claiming actions.

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -44,6 +44,7 @@ class ActionScheduler_QueueCleaner {
 				'modified'         => $cutoff,
 				'modified_compare' => '<=',
 				'per_page'         => $this->get_batch_size(),
+				'orderby'          => 'none',
 			) );
 
 			foreach ( $actions_to_delete as $action_id ) {
@@ -90,6 +91,7 @@ class ActionScheduler_QueueCleaner {
 			'modified_compare' => '<=',
 			'claimed'          => true,
 			'per_page'         => $this->get_batch_size(),
+			'orderby'          => 'none',
 		) );
 
 		foreach ( $actions_to_reset as $action_id ) {
@@ -118,6 +120,7 @@ class ActionScheduler_QueueCleaner {
 			'modified'         => $cutoff,
 			'modified_compare' => '<=',
 			'per_page'         => $this->get_batch_size(),
+			'orderby'          => 'none',
 		) );
 
 		foreach ( $actions_to_reset as $action_id ) {

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -242,9 +242,10 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 		while ( ! empty( $action_ids ) ) {
 			$action_ids = $this->query_actions(
 				array(
-					'hook' => $hook,
-					'status' => self::STATUS_PENDING,
+					'hook'     => $hook,
+					'status'   => self::STATUS_PENDING,
 					'per_page' => 1000,
+					'orderby'  => 'action_id',
 				)
 			);
 
@@ -266,9 +267,10 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 		while ( ! empty( $action_ids ) ) {
 			$action_ids = $this->query_actions(
 				array(
-					'group' => $group,
-					'status' => self::STATUS_PENDING,
+					'group'    => $group,
+					'status'   => self::STATUS_PENDING,
 					'per_page' => 1000,
+					'orderby'  => 'action_id',
 				)
 			);
 

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -315,8 +315,9 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 */
 	public function has_pending_actions_due() {
 		$pending_actions = $this->query_actions( array(
-			'date'   => as_get_datetime_object(),
-			'status' => ActionScheduler_Store::STATUS_PENDING,
+			'date'    => as_get_datetime_object(),
+			'status'  => ActionScheduler_Store::STATUS_PENDING,
+			'orderby' => 'none',
 		) );
 
 		return ! empty( $pending_actions );

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -368,7 +368,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		if ( 'select' === $select_or_count ) {
-			if ( strtoupper( $query[ 'order' ] ) == 'ASC' ) {
+			if ( 'ASC' === strtoupper( $query['order'] ) ) {
 				$order = 'ASC';
 			} else {
 				$order = 'DESC';
@@ -384,6 +384,9 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 					$sql .= " ORDER BY a.last_attempt_gmt $order";
 					break;
 				case 'none':
+					break;
+				case 'action_id':
+					$sql .= " ORDER BY a.action_id $order";
 					break;
 				case 'date':
 				default:
@@ -521,7 +524,8 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$query_args,
 			[
 				'per_page' => 1000,
-				'status' => self::STATUS_PENDING,
+				'status'   => self::STATUS_PENDING,
+				'orderby'  => 'action_id',
 			]
 		);
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -687,6 +687,14 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$order    = "ORDER BY attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT %d";
 		$params[] = $limit;
 
+		// Optimization for faster claiming of actions---use better upper bound for scheduled_date_gmt based on LIMIT.
+		$upper_bound_scheduled_date = $this->get_earliest_scheduled_date( $where, $params );
+		if ( '' !== $upper_bound_scheduled_date ) {
+			// This might seem superfluous, but MySQL optimizer will fix it.
+			$where .= ' AND scheduled_date_gmt <= %s';
+			array_splice( $params, count( $params ) - 1, 0, $upper_bound_scheduled_date );
+		}
+
 		$sql = $wpdb->prepare( "{$update} {$where} {$order}", $params );
 
 		$rows_affected = $wpdb->query( $sql );
@@ -695,6 +703,46 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		return (int) $rows_affected;
+	}
+
+	/**
+	 * Find upper bound for scheduled date.
+	 *
+	 * @param string    $where WHERE clause from the claim_actions function.
+	 * @param array     $params Parameters for SQL query from claim_actions function.
+	 *
+	 * @return string Upper bound for scheduled_date, or empty string if not successful.
+	 * @see claim_actions
+	 */
+	protected function get_earliest_scheduled_date( $where, $params ){
+		global $wpdb;
+		$query  = 'SELECT MAX(scheduled_date_gmt) FROM (';
+		$query .= " SELECT scheduled_date_gmt FROM {$wpdb->actionscheduler_actions} a ";
+		$query .= $where;
+		$query .= ' ORDER BY scheduled_date_gmt ASC';
+		$query .= ' LIMIT %d ) as sq';
+
+		/**
+		 * Remove first 3 elements from the array (that are used in the UPDATE ... SET) and leave
+		 * the rest used for filtering:
+		 *
+		 * - scheduled_date_gmt
+		 * - status (equal to pending status)
+		 * - hook_1
+		 * - hook_n
+		 * - group_id
+		 * - limit
+		 */
+		$params_select = array_slice( $params, 3 );
+
+		$sql = $wpdb->prepare( $query, $params_select );
+
+		$scheduled_date_gmt = $wpdb->get_var( $sql );
+		if ( false === $scheduled_date_gmt ) {
+			return '';
+		}
+
+		return (string) $scheduled_date_gmt;
 	}
 
 	/**


### PR DESCRIPTION
TL;DR is that the query that was in place was causing pretty bad congestion on the actions table due to the ordering/inefficient use of indexes. This PR is an attempt to optimize the action claiming query to minimize the deadlocks and lock timeouts. 

Hopefully closes #530 , together with #678.


##Testing instructions
1. create a new site
2. install & activate WC and action scheduler
3. generate at least 100k actions, or load the file with 1.3M actions into the database [wordpress-one-actions-only.sql.zip](https://github.com/woocommerce/action-scheduler/files/6206859/wordpress-one-actions-only.sql.zip)
(e.g. via phpmyadmin or via ssh `mysql -u root -p db_name < file.sql` ) and attach some function to action `create_next_action`)
4. enable multiple runners, e.g. by adding the code below
```
// mulitple queues
function eg_increase_action_scheduler_concurrent_batches( $concurrent_batches ) {
	return 10;
}
add_filter( 'action_scheduler_queue_runner_concurrent_batches', 'eg_increase_action_scheduler_concurrent_batches' );
```
5. start multiple (e.g. 5) runners from WP CLI, e.g. via `wp action-scheduler run --batch-size=100`
6. start `mysql` from ssh and run `SHOW PROCESSLIST` to see which queries are waiting for a long time for locks to get released. My output looked like this and the whole site was super slow:
```
MariaDB [(none)]> SHOW PROCESSLIST;
+-----+-------------+-----------+---------------+---------+------+--------------------------+------------------------------------------------------------------------------------------------------+----------+
| Id  | User        | Host      | db            | Command | Time | State                    | Info                                                                                                 | Progress |
+-----+-------------+-----------+---------------+---------+------+--------------------------+------------------------------------------------------------------------------------------------------+----------+
|   1 | system user |           | NULL          | Daemon  | NULL | InnoDB purge worker      | NULL                                                                                                 |    0.000 |
|   3 | system user |           | NULL          | Daemon  | NULL | InnoDB purge coordinator | NULL                                                                                                 |    0.000 |
|   2 | system user |           | NULL          | Daemon  | NULL | InnoDB purge worker      | NULL                                                                                                 |    0.000 |
|   4 | system user |           | NULL          | Daemon  | NULL | InnoDB purge worker      | NULL                                                                                                 |    0.000 |
|   5 | system user |           | NULL          | Daemon  | NULL | InnoDB shutdown handler  | NULL                                                                                                 |    0.000 |
| 138 | wp          | localhost | wordpress-one | Query   |   45 | Init for update          | UPDATE wp_actionscheduler_actions SET claim_id=60176, last_attempt_gmt='2021-03-23 15:08:03', last_a |    0.000 |
| 141 | root        | localhost | NULL          | Query   |    0 | Init                     | SHOW PROCESSLIST                                                                                     |    0.000 |
| 142 | wp          | localhost | wordpress-one | Query   |   19 | Init for update          | UPDATE wp_actionscheduler_actions SET claim_id=60177, last_attempt_gmt='2021-03-23 15:08:30', last_a |    0.000 |
| 143 | wp          | localhost | wordpress-one | Query   |   19 | Init for update          | UPDATE wp_actionscheduler_actions SET claim_id=60178, last_attempt_gmt='2021-03-23 15:08:30', last_a |    0.000 |
| 144 | wp          | localhost | wordpress-one | Query   |   16 | Sending data             | SELECT a.action_id FROM wp_actionscheduler_actions a WHERE 1=1 AND a.status='complete' AND a.last_at |    0.000 |
| 145 | wp          | localhost | wordpress-one | Query   |   11 | Sending data             | SELECT a.action_id FROM wp_actionscheduler_actions a WHERE 1=1 AND a.status='complete' AND a.last_at |    0.000 |
+-----+-------------+-----------+---------------+---------+------+--------------------------+------------------------------------------------------------------------------------------------------+----------+
11 rows in set (0.000 sec)
```
7. Now apply this branch and you shouldn't see any more stalled transactions (or UPDATE queries running for more than 1-2 secs)
```
MariaDB [wordpress-one]> SHOW PROCESSLIST;
+-----+-------------+-----------+---------------+---------+------+--------------------------+------------------------------------------------------------------------------------------------------+----------+
| Id  | User        | Host      | db            | Command | Time | State                    | Info                                                                                                 | Progress |
+-----+-------------+-----------+---------------+---------+------+--------------------------+------------------------------------------------------------------------------------------------------+----------+
|   1 | system user |           | NULL          | Daemon  | NULL | InnoDB purge worker      | NULL                                                                                                 |    0.000 |
|   2 | system user |           | NULL          | Daemon  | NULL | InnoDB purge worker      | NULL                                                                                                 |    0.000 |
|   3 | system user |           | NULL          | Daemon  | NULL | InnoDB purge worker      | NULL                                                                                                 |    0.000 |
|   4 | system user |           | NULL          | Daemon  | NULL | InnoDB purge coordinator | NULL                                                                                                 |    0.000 |
|   5 | system user |           | NULL          | Daemon  | NULL | InnoDB shutdown handler  | NULL                                                                                                 |    0.000 |
|  63 | root        | localhost | wordpress-one | Query   |    0 | Init                     | SHOW PROCESSLIST                                                                                     |    0.000 |
| 215 | root        | localhost | wordpress-one | Sleep   |  203 |                          | NULL                                                                                                 |    0.000 |
| 306 | wp          | localhost | wordpress-one | Query   |    0 | Init for update          | UPDATE wp_actionscheduler_actions SET claim_id=69077, last_attempt_gmt='2021-03-25 17:19:17', last_a |    0.000 |
| 307 | wp          | localhost | wordpress-one | Sleep   |    0 |                          | NULL                                                                                                 |    0.000 |
| 309 | wp          | localhost | wordpress-one | Query   |    0 | Sending data             | SELECT MAX(scheduled_date_gmt) FROM ( SELECT scheduled_date_gmt FROM wp_actionscheduler_actions a WH |    0.000 |
| 311 | wp          | localhost | wordpress-one | Query   |    0 | NULL                     | SELECT a.*, g.slug AS `group` FROM wp_actionscheduler_actions a LEFT JOIN wp_actionscheduler_groups  |    0.000 |
| 312 | wp          | localhost | wordpress-one | Query   |    0 | Sending data             | SELECT a.action_id FROM wp_actionscheduler_actions a WHERE 1=1 AND a.status='complete' AND a.last_at |    0.000 |
+-----+-------------+-----------+---------------+---------+------+--------------------------+------------------------------------------------------------------------------------------------------+----------+
12 rows in set (0.001 sec)
```

Note for future self: I generated the actions by putting this code into wc-core-functions:

```
add_action( 'shutdown', 'bootstrap' );

function bootstrap() {
	$pending_jobs = WC()->queue()->search(
		array(
			'per_page' => 1,
			'group'    => 'AS_PR_test_bootstrap',
		)
	);

	if ( ! $pending_jobs ) {
		$q = WC()->queue();
		$q->schedule_single( time() + 5, 'create_next_action', array( 0 ), 'AS_PR_test_bootstrap' );
	}
}

add_action( 'create_next_action', 'meh' );

function meh( $n ){
	$q = WC()->queue();
	for ( $i = 0; $i < 100; $i++ ){
		$q->schedule_single( time() + MINUTE_IN_SECONDS * $i, 'create_next_action', array( "$n.$i" ) );
	}
	sleep(1);
}
```

and then running the queue from WP CLI overnight
```
php8.0 wp-cli.phar action-scheduler run --batch-size=10
```