### PR TITLE
Remove docs recommendation to load AS with negative priority

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,7 @@ When the `action-scheduler.php` file is included, Action Scheduler will register
 
 Action Scheduler will register its version on `'plugins_loaded'` with priority `0` - after all other plugin codebases has been loaded. Therefore **the `action-scheduler.php` file must be included before `'plugins_loaded'` priority `0`**.
 
-It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'plugins_loaded'`, or you can use `'plugins_loaded'` with negative priority, like `-10`.
+It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'plugins_loaded'`.
 
 Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`.
 


### PR DESCRIPTION
Hi,

I'm not sure if opening a GH issue first would be better, than editing the docs directly... but here I am :)

In our plugin, we were requiring the AS library via the `plugins_loaded` action with priority `-10`. This requiring/loading of AS is not working as expected. I think the loading goes into the "Theme usage" use case, if there are no other plugins registering AS and this caused a fatal PHP error once we tested it with WooCommerce 5.5 Nightly (Trunk) -> which has the newer AS 3.2.0 version in it (our plugin is using 3.1.6 for now).

The Fatal error was:

```
PHP Fatal error:  Cannot declare class ActionScheduler, because the name is already in use in /.../wp-content/plugins/woocommerce/packages/action-scheduler/classes/abstracts/ActionScheduler.php on line 10
```

A simple fix was to require the AS library as soon as our plugin initializes (before the `plugins_loaded` hook is fired). So that's why I think the removed part of this doc (this PR) is needed.