### PR TITLE
fixes #730 issue: Call to undefined function as_next_scheduled_action()

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -27,7 +27,7 @@
 
 if ( ! function_exists( 'action_scheduler_register_3_dot_2_dot_1' ) ) {
 
-	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
+	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
@@ -43,14 +43,14 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_2_dot_1' ) ) {
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
-		if ( ! class_exists( 'ActionScheduler' ) ) {
+		if ( ! class_exists( 'ActionScheduler', false ) ) {
 			require_once( 'classes/abstracts/ActionScheduler.php' );
 			ActionScheduler::init( __FILE__ );
 		}
 	}
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
-	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
+	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
 		action_scheduler_initialize_3_dot_2_dot_1();
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();


### PR DESCRIPTION
The idea is to not load classes when checking for them. In other case class is loaded but `ActionScheduler::init` method is not called, and the next plugin or theme checking for it skips the `init` call, since class i already loaded.