### PR TITLE
Drop index claim_id and remove Order BY to reduce/resolve deadlocks

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -698,7 +698,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$params[] = $group_id;
 		}
 
-		$order    = "ORDER BY attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT %d";
+		$order    = "LIMIT %d";
 		$params[] = $limit;
 
 		$sql = $wpdb->prepare( "{$update} {$where} {$order}", $params );

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -16,7 +16,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 5;
+	protected $schema_version = 6;
 
 	public function __construct() {
 		$this->tables = [
@@ -64,7 +64,6 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
-				        KEY claim_id (claim_id),
 				        KEY `claim_id_status_scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
 				        ) $charset_collate";
 


### PR DESCRIPTION
Fixes #530 

Even though the new index (`claim_id_status_scheduled_date_gmt`) was added in #696, MySQL wouldn't pick it up in our case. Instead, it would use a composite index made up of the two separate indexes `claim_id` and `status`. This leads to slower query times and therefore, deadlocks.

Any query that takes advantage of `claim_id` would take equal advantage from `claim_id_status_scheduled_date_gmt` (as long as it's doesn't include `FORCE INDEX`), so dropping the `claim_id` index should have no negative impact in the performance.

Additionally, having `ORDER BY` in the query created in `claim_actions` makes the query excessively slow and leads to deadlocks. Without `ORDER BY`, the query will still pick the oldest actions (in most cases) because it'll order them based on the `action_id` which is sequential. For most cases, dropping the `ORDER BY` will have no negative impact, but will greatly improve performance and reduce deadlocks.
