### PR TITLE
Replace uses of `\ActionScheduler_Store::find_actions` with `\ActionScheduler_Store::query_actions`

### DIFF
--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -100,6 +100,28 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	abstract public function query_actions( $query = array(), $query_type = 'select' );
 
 	/**
+	 * Run query to get a single action ID.
+	 *
+	 * @since x.x.x
+	 *
+	 * @see ActionScheduler_Store::query_actions for $query arg usage but 'per_page' is always set to 1.
+	 *
+	 * @param array $query
+	 *
+	 * @return int|null
+	 */
+	public function query_action( $query ) {
+		$query['per_page'] = 1;
+		$results = $this->query_actions( $query );
+
+		if ( empty( $results ) ) {
+			return null;
+		} else {
+			return (int) $results[0];
+		}
+	}
+
+	/**
 	 * Get a count of all actions in the store, grouped by status
 	 *
 	 * @return array

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -104,7 +104,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 *
 	 * @since x.x.x
 	 *
-	 * @see ActionScheduler_Store::query_actions for $query arg usage but 'per_page' is always set to 1.
+	 * @see ActionScheduler_Store::query_actions for $query arg usage but 'per_page' and 'offset' can't be used.
 	 *
 	 * @param array $query
 	 *
@@ -112,6 +112,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 */
 	public function query_action( $query ) {
 		$query['per_page'] = 1;
+		$query['offset']   = 0;
 		$results = $this->query_actions( $query );
 
 		if ( empty( $results ) ) {

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -58,7 +58,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 		$params['per_page'] = 1;
 
 		if ( ! empty( $params['status'] ) ) {
-			if ( self::STATUS_PENDING == $params['status'] ) {
+			if ( self::STATUS_PENDING === $params['status'] ) {
 				$params['order'] = 'ASC'; // Find the next action that matches.
 			} else {
 				$params['order'] = 'DESC'; // Find the most recent action that matches.

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -38,13 +38,37 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	/**
 	 * Find an action.
 	 *
-	 * @deprecated in x.x.x, use the query_actions method instead.
-	 * 
-	 * @param string $hook Hook name/slug.
-	 * @param array  $params Hook arguments.
-	 * @return string ID of the next action matching the criteria.
+	 * Note: the query ordering changes based on the passed 'status' value.
+	 *
+	 * @param string $hook Action hook.
+	 * @param array  $params Parameters of the action to find.
+	 *
+	 * @return string|null ID of the next action matching the criteria or NULL if not found.
 	 */
-	abstract public function find_action( $hook, $params = array() );
+	public function find_action( $hook, $params = [] ) {
+		$params = wp_parse_args( $params, [
+			'args'     => null,
+			'status'   => self::STATUS_PENDING,
+			'group'    => '',
+		] );
+
+		// There params are fixed for this method
+		$params['hook']     = $hook;
+		$params['orderby']  = 'date';
+		$params['per_page'] = 1;
+
+		if ( ! empty( $params['status'] ) ) {
+			if ( self::STATUS_PENDING == $params['status'] ) {
+				$params['order'] = 'ASC'; // Find the next action that matches.
+			} else {
+				$params['order'] = 'DESC'; // Find the most recent action that matches.
+			}
+		}
+
+		$results = $this->query_actions( $params );
+
+		return empty( $results ) ? null : $results[0];
+	}
 
 	/**
 	 * Query for action count or list of action IDs.

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -92,7 +92,6 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 *      @type int          $orderby          Accepted values are 'hook', 'group', 'modified', 'date' or 'none'. Defaults to 'date'.
 	 *      @type string       $order            Accepted values are 'ASC' or 'DESC'. Defaults to 'ASC'.
 	 * }
-	 * @param array  $query Query parameters.
 	 * @param string $query_type Whether to select or count the results. Default, select.
 	 *
 	 * @return string|array|null The IDs of actions matching the query. Null on failure.
@@ -106,7 +105,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 *
 	 * @see ActionScheduler_Store::query_actions for $query arg usage but 'per_page' and 'offset' can't be used.
 	 *
-	 * @param array $query
+	 * @param array $query Query parameters.
 	 *
 	 * @return int|null
 	 */

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -112,7 +112,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	public function query_action( $query ) {
 		$query['per_page'] = 1;
 		$query['offset']   = 0;
-		$results = $this->query_actions( $query );
+		$results           = $this->query_actions( $query );
 
 		if ( empty( $results ) ) {
 			return null;

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -36,6 +36,10 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	abstract public function fetch_action( $action_id );
 
 	/**
+	 * Find an action.
+	 *
+	 * @deprecated in x.x.x, use the query_actions method instead.
+	 * 
 	 * @param string $hook Hook name/slug.
 	 * @param array  $params Hook arguments.
 	 * @return string ID of the next action matching the criteria.

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -45,14 +45,17 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 *
 	 * @return string|null ID of the next action matching the criteria or NULL if not found.
 	 */
-	public function find_action( $hook, $params = [] ) {
-		$params = wp_parse_args( $params, [
-			'args'     => null,
-			'status'   => self::STATUS_PENDING,
-			'group'    => '',
-		] );
+	public function find_action( $hook, $params = array() ) {
+		$params = wp_parse_args(
+			$params,
+			array(
+				'args'   => null,
+				'status' => self::STATUS_PENDING,
+				'group'  => '',
+			)
+		);
 
-		// There params are fixed for this method
+		// These params are fixed for this method.
 		$params['hook']     = $hook;
 		$params['orderby']  = 'date';
 		$params['per_page'] = 1;

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -228,59 +228,6 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	}
 
 	/**
-	 * Find an action.
-	 *
-	 * @deprecated in x.x.x, use the query_actions method instead.
-	 *
-	 * @param string $hook Action hook.
-	 * @param array  $params Parameters of the action to find.
-	 *
-	 * @return string|null ID of the next action matching the criteria or NULL if not found.
-	 */
-	public function find_action( $hook, $params = [] ) {
-		$params = wp_parse_args( $params, [
-			'args'   => null,
-			'status' => self::STATUS_PENDING,
-			'group'  => '',
-		] );
-
-		/** @var wpdb $wpdb */
-		global $wpdb;
-		$query = "SELECT a.action_id FROM {$wpdb->actionscheduler_actions} a";
-		$args  = [];
-		if ( ! empty( $params[ 'group' ] ) ) {
-			$query  .= " INNER JOIN {$wpdb->actionscheduler_groups} g ON g.group_id=a.group_id AND g.slug=%s";
-			$args[] = $params[ 'group' ];
-		}
-		$query  .= " WHERE a.hook=%s";
-		$args[] = $hook;
-		if ( ! is_null( $params[ 'args' ] ) ) {
-			$query  .= " AND a.args=%s";
-			$args[] = $this->get_args_for_query( $params[ 'args' ] );
-		}
-
-		$order = 'ASC';
-		if ( ! empty( $params[ 'status' ] ) ) {
-			$query  .= " AND a.status=%s";
-			$args[] = $params[ 'status' ];
-
-			if ( self::STATUS_PENDING == $params[ 'status' ] ) {
-				$order = 'ASC'; // Find the next action that matches.
-			} else {
-				$order = 'DESC'; // Find the most recent action that matches.
-			}
-		}
-
-		$query .= " ORDER BY scheduled_date_gmt $order LIMIT 1";
-
-		$query = $wpdb->prepare( $query, $args );
-
-		$id = $wpdb->get_var( $query );
-
-		return $id;
-	}
-
-	/**
 	 * Returns the SQL statement to query (or count) actions.
 	 *
 	 * @since x.x.x $query['status'] accepts array of statuses instead of a single status.

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -230,6 +230,8 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	/**
 	 * Find an action.
 	 *
+	 * @deprecated in x.x.x, use the query_actions method instead.
+	 *
 	 * @param string $hook Action hook.
 	 * @param array  $params Parameters of the action to find.
 	 *

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -135,6 +135,8 @@ class ActionScheduler_HybridStore extends Store {
 	 * After it migrates, the secondary store will logically contain
 	 * the next matching action, so return the result thence.
 	 *
+	 * @deprecated in x.x.x, use the query_actions method instead.
+	 *
 	 * @param string $hook
 	 * @param array  $params
 	 *

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -135,8 +135,6 @@ class ActionScheduler_HybridStore extends Store {
 	 * After it migrates, the secondary store will logically contain
 	 * the next matching action, so return the result thence.
 	 *
-	 * @deprecated in x.x.x, use the query_actions method instead.
-	 *
 	 * @param string $hook
 	 * @param array  $params
 	 *

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -225,6 +225,10 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	}
 
 	/**
+	 * Find an action.
+	 *
+	 * @deprecated in x.x.x, use the query_actions method instead.
+	 *
 	 * @param string $hook
 	 * @param array $params
 	 *

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -225,65 +225,6 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	}
 
 	/**
-	 * Find an action.
-	 *
-	 * @deprecated in x.x.x, use the query_actions method instead.
-	 *
-	 * @param string $hook
-	 * @param array $params
-	 *
-	 * @return string ID of the next action matching the criteria or NULL if not found
-	 */
-	public function find_action( $hook, $params = array() ) {
-		$params = wp_parse_args( $params, array(
-			'args' => NULL,
-			'status' => ActionScheduler_Store::STATUS_PENDING,
-			'group' => '',
-		));
-		/** @var wpdb $wpdb */
-		global $wpdb;
-		$query = "SELECT p.ID FROM {$wpdb->posts} p";
-		$args = array();
-		if ( !empty($params['group']) ) {
-			$query .= " INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id=p.ID";
-			$query .= " INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
-			$query .= " INNER JOIN {$wpdb->terms} t ON tt.term_id=t.term_id AND t.slug=%s";
-			$args[] = $params['group'];
-		}
-		$query .= " WHERE p.post_title=%s";
-		$args[] = $hook;
-		$query .= " AND p.post_type=%s";
-		$args[] = self::POST_TYPE;
-		if ( !is_null($params['args']) ) {
-			$query .= " AND p.post_content=%s";
-			$args[] = json_encode($params['args']);
-		}
-
-		if ( ! empty( $params['status'] ) ) {
-			$query .= " AND p.post_status=%s";
-			$args[] = $this->get_post_status_by_action_status( $params['status'] );
-		}
-
-		switch ( $params['status'] ) {
-			case self::STATUS_COMPLETE:
-			case self::STATUS_RUNNING:
-			case self::STATUS_FAILED:
-				$order = 'DESC'; // Find the most recent action that matches
-				break;
-			case self::STATUS_PENDING:
-			default:
-				$order = 'ASC'; // Find the next action that matches
-				break;
-		}
-		$query .= " ORDER BY post_date_gmt $order LIMIT 1";
-
-		$query = $wpdb->prepare( $query, $args );
-
-		$id = $wpdb->get_var($query);
-		return $id;
-	}
-
-	/**
 	 * Returns the SQL statement to query (or count) actions.
 	 *
 	 * @param array $query Filtering options

--- a/functions.php
+++ b/functions.php
@@ -181,23 +181,25 @@ function as_next_scheduled_action( $hook, $args = null, $group = '' ) {
 	}
 
 	$params['status'] = ActionScheduler_Store::STATUS_RUNNING;
-	$action_id = ActionScheduler::store()->query_action( $params );
+	$action_id        = ActionScheduler::store()->query_action( $params );
 	if ( $action_id ) {
 		return true;
 	}
 
 	$params['status'] = ActionScheduler_Store::STATUS_PENDING;
-	$action_id = ActionScheduler::store()->query_action( $params );
-	if ( null === $action_id  ) {
+	$action_id        = ActionScheduler::store()->query_action( $params );
+	if ( null === $action_id ) {
 		return false;
 	}
-	$action = ActionScheduler::store()->fetch_action( $action_id );
+
+	$action         = ActionScheduler::store()->fetch_action( $action_id );
 	$scheduled_date = $action->get_schedule()->get_date();
 	if ( $scheduled_date ) {
 		return (int) $scheduled_date->format( 'U' );
 	} elseif ( null === $scheduled_date ) { // pending async action with NullSchedule
 		return true;
 	}
+
 	return false;
 }
 

--- a/functions.php
+++ b/functions.php
@@ -104,18 +104,27 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	$params = array();
-	if ( is_array($args) ) {
+	$params = array(
+		'hook'     => $hook,
+		'status'   => ActionScheduler_Store::STATUS_PENDING,
+		'orderby'  => 'date',
+		'order'    => 'ASC',
+		'per_page' => 1,
+	);
+	if ( is_array( $args ) ) {
 		$params['args'] = $args;
 	}
-	if ( !empty($group) ) {
+	if ( ! empty( $group ) ) {
 		$params['group'] = $group;
 	}
-	$job_id = ActionScheduler::store()->find_action( $hook, $params );
 
-	if ( ! empty( $job_id ) ) {
-		ActionScheduler::store()->cancel_action( $job_id );
+	$results = ActionScheduler::store()->query_actions( $params );
+	if ( empty( $results ) ) {
+		return null;
 	}
+
+	$job_id = $results[0];
+	ActionScheduler::store()->cancel_action( $job_id );
 
 	return $job_id;
 }

--- a/functions.php
+++ b/functions.php
@@ -170,30 +170,37 @@ function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
  *
  * @return int|bool The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
  */
-function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+function as_next_scheduled_action( $hook, $args = null, $group = '' ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return false;
 	}
-	$params = array();
-	if ( is_array($args) ) {
+
+	$params = array(
+		'hook'     => $hook,
+		'orderby'  => 'date',
+		'order'    => 'ASC',
+		'per_page' => 1,
+	);
+
+	if ( is_array( $args ) ) {
 		$params['args'] = $args;
 	}
-	if ( !empty($group) ) {
+	if ( ! empty( $group ) ) {
 		$params['group'] = $group;
 	}
 
 	$params['status'] = ActionScheduler_Store::STATUS_RUNNING;
-	$job_id = ActionScheduler::store()->find_action( $hook, $params );
-	if ( ! empty( $job_id ) ) {
+	$results = ActionScheduler::store()->query_actions( $params );
+	if ( ! empty( $results ) ) {
 		return true;
 	}
 
 	$params['status'] = ActionScheduler_Store::STATUS_PENDING;
-	$job_id = ActionScheduler::store()->find_action( $hook, $params );
-	if ( empty($job_id) ) {
+	$results = ActionScheduler::store()->query_actions( $params );
+	if ( empty( $results ) ) {
 		return false;
 	}
-	$job = ActionScheduler::store()->fetch_action( $job_id );
+	$job = ActionScheduler::store()->fetch_action( $results[0] );
 	$scheduled_date = $job->get_schedule()->get_date();
 	if ( $scheduled_date ) {
 		return (int) $scheduled_date->format( 'U' );


### PR DESCRIPTION
The data store methods `\ActionScheduler_Store::find_actions` and `\ActionScheduler_Store::query_actions` essentially perform the same function and contain a lot of duplicate code. `find_actions` is less capable and makes a bunch of assumptions which are not implied in the name which makes `query_actions` a much better single choice to use moving forward.

This PR updates the `as_next_scheduled_action()` and `as_unschedule_action()` functions to use the preferred `query_actions` method.

Initially commented here: https://github.com/woocommerce/action-scheduler/pull/688#discussion_r696936795

The only risk I see here is that `find_action` has greater test coverage than `query_actions`. 

Note: `find_action` uses an INNER JOIN while `query_actions` uses as LEFT JOIN. This doesn't affect the end result AFAICS.