### PR TITLE
fixing phpcs for ActionScheduler_Schedule_Deprecated

### DIFF
--- a/deprecated/ActionScheduler_Schedule_Deprecated.php
+++ b/deprecated/ActionScheduler_Schedule_Deprecated.php
@@ -9,11 +9,11 @@ abstract class ActionScheduler_Schedule_Deprecated implements ActionScheduler_Sc
 	 * Get the date & time this schedule was created to run, or calculate when it should be run
 	 * after a given date & time.
 	 *
-	 * @param DateTime $after
+	 * @param DateTime $after DateTime to calculate against.
 	 *
 	 * @return DateTime|null
 	 */
-	public function next( DateTime $after = NULL ) {
+	public function next( DateTime $after = null ) {
 		if ( empty( $after ) ) {
 			$return_value       = $this->get_date();
 			$replacement_method = 'get_date()';
@@ -22,7 +22,7 @@ abstract class ActionScheduler_Schedule_Deprecated implements ActionScheduler_Sc
 			$replacement_method = 'get_next( $after )';
 		}
 
-		_deprecated_function( __METHOD__, '3.0.0', __CLASS__ . '::' . $replacement_method );
+		_deprecated_function( __METHOD__, '3.0.0', __CLASS__ . '::' . $replacement_method ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		return $return_value;
 	}


### PR DESCRIPTION
This PR fixes issues reported here https://github.com/woocommerce/action-scheduler/issues/666 

It adds comments for 

`// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped`

and missing parameter description

PHPCS latest scan result:

```
FILE: .../action-scheduler/deprecated/ActionScheduler_Schedule_Deprecated.php
-------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------------------
 1 | ERROR | Missing file doc comment
-------------------------------------------------------------------------------------------------

Time: 454ms; Memory: 14MB
```