### PR TITLE
ActionScheduler_DBLogger.php  phpcs fixes

### DIFF
--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -31,12 +31,16 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 
 		/** @var \wpdb $wpdb */
 		global $wpdb;
-		$wpdb->insert( $wpdb->actionscheduler_logs, [
-			'action_id'      => $action_id,
-			'message'        => $message,
-			'log_date_gmt'   => $date_gmt,
-			'log_date_local' => $date_local,
-		], [ '%d', '%s', '%s', '%s' ] );
+		$wpdb->insert(
+			$wpdb->actionscheduler_logs,
+			array(
+				'action_id'      => $action_id,
+				'message'        => $message,
+				'log_date_gmt'   => $date_gmt,
+				'log_date_local' => $date_local,
+			),
+			array( '%d', '%s', '%s', '%s' )
+		);
 
 		return $wpdb->insert_id;
 	}
@@ -90,7 +94,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 
 		$records = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_logs} WHERE action_id=%d", $action_id ) );
 
-		return array_map( [ $this, 'create_entry_from_db_record' ], $records );
+		return array_map( array( $this, 'create_entry_from_db_record' ), $records );
 	}
 
 	/**
@@ -105,7 +109,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 
 		parent::init();
 
-		add_action( 'action_scheduler_deleted_action', [ $this, 'clear_deleted_action_logs' ], 10, 1 );
+		add_action( 'action_scheduler_deleted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
 	}
 
 	/**
@@ -116,7 +120,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	public function clear_deleted_action_logs( $action_id ) {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
-		$wpdb->delete( $wpdb->actionscheduler_logs, [ 'action_id' => $action_id, ], [ '%d' ] );
+		$wpdb->delete( $wpdb->actionscheduler_logs, array( 'action_id' => $action_id ), array( '%d' ) );
 	}
 
 	/**
@@ -138,13 +142,13 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		$message    = __( 'action canceled', 'action-scheduler' );
 		$format     = '(%d, ' . $wpdb->prepare( '%s, %s, %s', $message, $date_gmt, $date_local ) . ')';
 		$sql_query  = "INSERT {$wpdb->actionscheduler_logs} (action_id, message, log_date_gmt, log_date_local) VALUES ";
-		$value_rows = [];
+		$value_rows = array();
 
 		foreach ( $action_ids as $action_id ) {
-			$value_rows[] = $wpdb->prepare( $format, $action_id );
+			$value_rows[] = $wpdb->prepare( $format, $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 		$sql_query .= implode( ',', $value_rows );
 
-		$wpdb->query( $sql_query );
+		$wpdb->query( $sql_query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
 }

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -29,7 +29,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
 		$date_local = $date->format( 'Y-m-d H:i:s' );
 
-		/** @var \wpdb $wpdb */
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		global $wpdb;
 		$wpdb->insert(
 			$wpdb->actionscheduler_logs,
@@ -53,7 +53,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	 * @return ActionScheduler_LogEntry
 	 */
 	public function get_entry( $entry_id ) {
-		/** @var \wpdb $wpdb */
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		global $wpdb;
 		$entry = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_logs} WHERE log_id=%d", $entry_id ) );
 
@@ -89,7 +89,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	 * @return ActionScheduler_LogEntry[]
 	 */
 	public function get_logs( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		global $wpdb;
 
 		$records = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_logs} WHERE action_id=%d", $action_id ) );
@@ -118,7 +118,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	 * @param int $action_id Action ID.
 	 */
 	public function clear_deleted_action_logs( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		global $wpdb;
 		$wpdb->delete( $wpdb->actionscheduler_logs, array( 'action_id' => $action_id ), array( '%d' ) );
 	}
@@ -133,7 +133,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 			return;
 		}
 
-		/** @var \wpdb $wpdb */
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		global $wpdb;
 		$date     = as_get_datetime_object();
 		$date_gmt = $date->format( 'Y-m-d H:i:s' );


### PR DESCRIPTION
This PR will address the issue detailed in https://github.com/woocommerce/action-scheduler/issues/662

It will add those fixes along with adding the PHPCS ignore rule for `Generic.Commenting.DocComment.MissingShort` and other PHPCS warning fixes.

Latest PHPCS scan:

```
# ./vendor/bin/phpcs classes/data-stores/ActionScheduler_DBLogger.php

FILE: .../action-scheduler/classes/data-stores/ActionScheduler_DBLogger.php
-----------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------
 1 | ERROR | Missing file doc comment
-----------------------------------------------------------------------------------------------

```