### PR TITLE
adding admin list table screen pagination

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -180,8 +180,34 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			'plural'   => 'action-scheduler',
 			'ajax'     => false,
 		) );
+
+		add_screen_option(
+			'per_page',
+			array(
+				'default' => $this->items_per_page,
+			)
+		);
+
+		add_filter( 'set-screen-option', array( &$this, 'set_screen_option' ), 10, 3 );
+		set_screen_options();
 	}
 
+	/**
+	 * Set screen option.
+	 *
+	 * @param [type] $status Default false (to skip saving the current option)
+	 * @param [type] $option Screen option name.
+	 * @param [type] $value  Screen option value.
+	 * @return int
+	 */
+	public function set_screen_option( $status, $option, $value ) {
+
+        if (str_replace('-', '_', $this->screen->base) . '_per_page' === $option) {
+            return $value;
+        }
+
+		return $status;
+	}
 	/**
 	 * Convert an interval of seconds into a two part human friendly string.
 	 *
@@ -549,7 +575,8 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	public function prepare_items() {
 		$this->prepare_column_headers();
 
-		$per_page = $this->get_items_per_page( $this->package . '_items_per_page', $this->items_per_page );
+		$per_page = $this->get_items_per_page( str_replace( '-', '_', $this->screen->base) . '_per_page', $this->items_per_page);
+
 		$query = array(
 			'per_page' => $per_page,
 			'offset'   => $this->get_items_offset(),

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -202,8 +202,8 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	public function set_screen_option( $status, $option, $value ) {
 
-        if (str_replace('-', '_', $this->screen->base) . '_per_page' === $option) {
-            return $value;
+        if ( str_replace( '-', '_', $this->screen->base ) . '_per_page' === $option ) {
+			return $value;
         }
 
 		return $status;
@@ -575,7 +575,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	public function prepare_items() {
 		$this->prepare_column_headers();
 
-		$per_page = $this->get_items_per_page( str_replace( '-', '_', $this->screen->base) . '_per_page', $this->items_per_page);
+		$per_page = $this->get_items_per_page( str_replace( '-', '_', $this->screen->base ) . '_per_page', $this->items_per_page );
 
 		$query = array(
 			'per_page' => $per_page,

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -195,16 +195,16 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Set screen option.
 	 *
-	 * @param [type] $status Default false (to skip saving the current option)
-	 * @param [type] $option Screen option name.
-	 * @param [type] $value  Screen option value.
+	 * @param mixed  $status Default false (to skip saving the current option).
+	 * @param string $option Screen option name.
+	 * @param int    $value  Screen option value.
 	 * @return int
 	 */
 	public function set_screen_option( $status, $option, $value ) {
 
-        if ( str_replace( '-', '_', $this->screen->base ) . '_per_page' === $option ) {
+		if ( str_replace( '-', '_', $this->screen->base ) . '_per_page' === $option ) {
 			return $value;
-        }
+		}
 
 		return $status;
 	}

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -202,7 +202,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	public function set_screen_option( $status, $option, $value ) {
 
-		if ( str_replace( '-', '_', $this->screen->base ) . '_per_page' === $option ) {
+		if ( str_replace( '-', '_', $this->screen->id ) . '_per_page' === $option ) {
 			return $value;
 		}
 
@@ -575,7 +575,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	public function prepare_items() {
 		$this->prepare_column_headers();
 
-		$per_page = $this->get_items_per_page( str_replace( '-', '_', $this->screen->base ) . '_per_page', $this->items_per_page );
+		$per_page = $this->get_items_per_page( str_replace( '-', '_', $this->screen->id ) . '_per_page', $this->items_per_page );
 
 		$query = array(
 			'per_page' => $per_page,


### PR DESCRIPTION
This PR fixes https://github.com/woocommerce/action-scheduler/issues/601 and adds the missing pagination when Action Scheduler is accessed from the WP-Admin->Tools->Scheduled Actions menu.

The changes include:

- `add_screen_option` to the ActionScheduler_ListTable class
- `set_screen_option` method to save the pagination option
- changes to the `prepare_items` method so the proper naming of the `_per_page` option is used so, to correctly reference the saved screen option, we need to replace `$this->package . '_items_per_page'` with `str_replace( '-', '_', $this->screen->id ) . '_per_page'` or similar

I am not sure if we should change the `ActionScheduler_Abstract_ListTable` which still has references to the `$this->package . '_items_per_page'`

![Screen Recording 2021-10-04 at 12 09 31](https://user-images.githubusercontent.com/537751/135826312-6f6eebc1-f5ac-40bf-bc2b-0e61043bb150.gif)



