### PR TITLE
Feature: Custom User-Agent for Action Scheduler requests

### DIFF
--- a/lib/WP_Async_Request.php
+++ b/lib/WP_Async_Request.php
@@ -4,6 +4,7 @@
  *
  * @package WP-Background-Processing
  */
+
 /*
 Library URI: https://github.com/deliciousbrains/wp-background-processing/blob/fbbc56f2480910d7959972ec9ec0819a13c6150a/classes/wp-async-request.php
 Author: Delicious Brains Inc.
@@ -133,12 +134,15 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->post_args;
 			}
 
+			$versions = ActionScheduler_Versions::instance();
+
 			return array(
-				'timeout'   => 0.01,
-				'blocking'  => false,
-				'body'      => $this->data,
-				'cookies'   => $_COOKIE,
-				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+				'timeout'    => 0.01,
+				'blocking'   => false,
+				'body'       => $this->data,
+				'cookies'    => $_COOKIE,
+				'user-agent' => apply_filters( 'action_scheduler_user_agent', 'Action Scheduler/' . $versions->latest_version() ),
+				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ),
 			);
 		}
 
@@ -148,7 +152,7 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 		 * Check for correct nonce and pass to handler.
 		 */
 		public function maybe_handle() {
-			// Don't lock up other requests while processing
+			// Don't lock up other requests while processing.
 			session_write_close();
 
 			check_ajax_referer( $this->identifier, 'nonce' );


### PR DESCRIPTION
This PR will fix the issue raised in #787 by adding a custom User-Agent filtered option to the default args of the `wp_remote_post` call in `WP_Async_Request` class.

I've been testing this using XDebug to make sure the new User-Agent name gets properly passed to the request call.

<img width="1400" alt="Screenshot 2021-11-24 at 09 33 35" src="https://user-images.githubusercontent.com/537751/143194970-2cfe31dd-82f4-4646-b719-8cf00fe69529.png">

I don't see any performance-related issues that this PR code would raise.

The PR also add a PHPCS fix for a missing empty line and ending comment colon.
