### PR TITLE
Implement SKIP LOCKED during action claiming

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request
 jobs:
   test:
-    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} MU ${{ matrix.multisite }}
+    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} MU ${{ matrix.multisite }} DB ${{ matrix.db }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
@@ -11,8 +11,9 @@ jobs:
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
         php: [ '7.1', '7.4', '8.0', '8.3' ]
-        wp: [ '6.4', '6.5', '6.6', 'latest', 'nightly' ]
+        wp: [ '6.5', '6.6', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
+        db: [ 'mysql:5.6', 'mysql:8.1', 'mariadb:10.4', 'mariadb:10.6']
         exclude:
           # WordPress 6.6+ requires PHP 7.2+
           - php: 7.1
@@ -23,7 +24,7 @@ jobs:
             wp: nightly
     services:
       database:
-        image: mysql:5.6
+        image: ${{ matrix.db }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
@@ -85,7 +86,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y subversion
 
       - name: Init DB and WP
-        run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
+        run: |
+          # Use mysql_native_password when using PHP < 7.4 and MySQL >= 8.0
+          if [ "$(php -r 'echo version_compare(PHP_VERSION, "7.4", "<");')" -eq 1 ] && [ "${{ matrix.db }}" == "mysql:8.1" ]; then
+            mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+          fi
+          ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '7.1', '7.4', '8.0', '8.3' ]
-        wp: [ '6.5', '6.6', 'latest', 'nightly' ]
-        multisite: [ '0', '1' ]
-        db: [ 'mysql:5.6', 'mysql:8.1', 'mariadb:10.4', 'mariadb:10.6']
+        php: [ '8.3' ]
+        wp: [ 'latest' ]
+        multisite: [ '0' ]
+        db: [ 'mariadb:10.6']
         exclude:
           # WordPress 6.6+ requires PHP 7.2+
           - php: 7.1

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '8.3' ]
-        wp: [ 'latest' ]
-        multisite: [ '0' ]
-        db: [ 'mariadb:10.6']
+        php: [ '7.1', '7.4', '8.0', '8.3' ]
+        wp: [ '6.5', '6.6', 'latest', 'nightly' ]
+        multisite: [ '0', '1' ]
+        db: [ 'mysql:5.6', 'mysql:8.1', 'mariadb:10.4', 'mariadb:10.6']
         exclude:
           # WordPress 6.6+ requires PHP 7.2+
           - php: 7.1

--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -162,10 +162,19 @@ class ActionScheduler_DataController {
 			return;
 		}
 
-		$wp_object_cache->group_ops      = array();
-		$wp_object_cache->stats          = array();
-		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache          = array();
+		// Not all drop-ins support these props, however, there may be existing installations that rely on these being cleared.
+		if ( property_exists( $wp_object_cache, 'group_ops' ) ) {
+			$wp_object_cache->group_ops = array();
+		}
+		if ( property_exists( $wp_object_cache, 'stats' ) ) {
+			$wp_object_cache->stats = array();
+		}
+		if ( property_exists( $wp_object_cache, 'memcache_debug' ) ) {
+			$wp_object_cache->memcache_debug = array();
+		}
+		if ( property_exists( $wp_object_cache, 'cache' ) ) {
+			$wp_object_cache->cache = array();
+		}
 
 		if ( is_callable( array( $wp_object_cache, '__remoteset' ) ) ) {
 			call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important!

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -932,15 +932,12 @@ AND `group_id` = %d
 		 */
 		global $wpdb;
 
+		// Start by building a SELECT query for which actions we want to claim.
+		$select = "SELECT action_id from {$wpdb->actionscheduler_actions}";
+		$select_params = [];
+
 		$now  = as_get_datetime_object();
 		$date = is_null( $before_date ) ? $now : clone $before_date;
-		// can't use $wpdb->update() because of the <= condition.
-		$update = "UPDATE {$wpdb->actionscheduler_actions} SET claim_id=%d, last_attempt_gmt=%s, last_attempt_local=%s";
-		$params = array(
-			$claim_id,
-			$now->format( 'Y-m-d H:i:s' ),
-			current_time( 'mysql' ),
-		);
 
 		// Set claim filters.
 		if ( ! empty( $hooks ) ) {
@@ -954,14 +951,14 @@ AND `group_id` = %d
 			$group = $this->get_claim_filter( 'group' );
 		}
 
-		$where    = 'WHERE claim_id = 0 AND scheduled_date_gmt <= %s AND status=%s';
-		$params[] = $date->format( 'Y-m-d H:i:s' );
-		$params[] = self::STATUS_PENDING;
+		$where           = 'WHERE claim_id = 0 AND scheduled_date_gmt <= %s AND status=%s';
+		$select_params[] = $date->format( 'Y-m-d H:i:s' );
+		$select_params[] = self::STATUS_PENDING;
 
 		if ( ! empty( $hooks ) ) {
-			$placeholders = array_fill( 0, count( $hooks ), '%s' );
-			$where       .= ' AND hook IN (' . join( ', ', $placeholders ) . ')';
-			$params       = array_merge( $params, array_values( $hooks ) );
+			$placeholders  = array_fill( 0, count( $hooks ), '%s' );
+			$where        .= ' AND hook IN (' . join( ', ', $placeholders ) . ')';
+			$select_params = array_merge( $select_params, array_values( $hooks ) );
 		}
 
 		$group_operator = 'IN';
@@ -1003,11 +1000,21 @@ AND `group_id` = %d
 		 * @param string $claim_id Claim Id.
 		 * @param array  $hooks Hooks to filter for.
 		 */
-		$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
-		$params[] = $limit;
+		$order           = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
+		$select_params[] = $limit;
 
-		$sql           = $wpdb->prepare( "{$update} {$where} {$order} LIMIT %d", $params ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
-		$rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// Selecting the action_ids that we plan to claim, while skipping any locked rows to avoid deadlocking.
+		$select_sql = $wpdb->prepare( "{$select} {$where} {$order} LIMIT %d FOR UPDATE SKIP LOCKED", $select_params );
+
+		// Now place it into an UPDATE statement by joining the result sets, allowing for the SKIP LOCKED behavior to take effect.
+		$update_sql    = "UPDATE {$wpdb->actionscheduler_actions} t1 JOIN ( $select_sql ) t2 ON t1.action_id = t2.action_id SET claim_id=%d, last_attempt_gmt=%s, last_attempt_local=%s";
+		$update_params = array(
+			$claim_id,
+			$now->format( 'Y-m-d H:i:s' ),
+			current_time( 'mysql' ),
+		);
+
+		$rows_affected = $wpdb->query( $wpdb->prepare( $update_sql, $update_params ) );
 		if ( false === $rows_affected ) {
 			$error = empty( $wpdb->last_error )
 				? _x( 'unknown', 'database error', 'action-scheduler' )

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1029,7 +1029,7 @@ AND `group_id` = %d
 	}
 
 	/**
-	 * Determines whether the database supports using SKIP LOCKED.
+	 * Determines whether the database supports using SKIP LOCKED. This logic mimicks the $wpdb::has_cap() logic.
 	 *
 	 * SKIP_LOCKED support was added to MariaDB in 10.6.0 and to MySQL in 8.0.1
 	 *

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1039,7 +1039,7 @@ AND `group_id` = %d
 		global $wpdb;
 		$db_version     = $wpdb->db_version();
 		$db_server_info = $wpdb->db_server_info();
-		$is_mariadb     = ( false !== str_contains( $db_server_info, 'MariaDB' ) );
+		$is_mariadb     = ( false !== strpos( $db_server_info, 'MariaDB' ) );
 
 		if ( $is_mariadb &&
 		     '5.5.5' === $db_version &&

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -931,11 +931,6 @@ AND `group_id` = %d
 		 * @var \wpdb $wpdb
 		 */
 		global $wpdb;
-
-		// Start by building a SELECT query for which actions we want to claim.
-		$select = "SELECT action_id from {$wpdb->actionscheduler_actions}";
-		$select_params = [];
-
 		$now  = as_get_datetime_object();
 		$date = is_null( $before_date ) ? $now : clone $before_date;
 
@@ -951,14 +946,16 @@ AND `group_id` = %d
 			$group = $this->get_claim_filter( 'group' );
 		}
 
-		$where           = 'WHERE claim_id = 0 AND scheduled_date_gmt <= %s AND status=%s';
-		$select_params[] = $date->format( 'Y-m-d H:i:s' );
-		$select_params[] = self::STATUS_PENDING;
+		$where        = 'WHERE claim_id = 0 AND scheduled_date_gmt <= %s AND status=%s';
+		$where_params = array(
+			$date->format( 'Y-m-d H:i:s' ),
+			self::STATUS_PENDING,
+		);
 
 		if ( ! empty( $hooks ) ) {
-			$placeholders  = array_fill( 0, count( $hooks ), '%s' );
+			$placeholders = array_fill( 0, count( $hooks ), '%s' );
 			$where        .= ' AND hook IN (' . join( ', ', $placeholders ) . ')';
-			$select_params = array_merge( $select_params, array_values( $hooks ) );
+			$where_params = array_merge( $where_params, array_values( $hooks ) );
 		}
 
 		$group_operator = 'IN';
@@ -993,18 +990,18 @@ AND `group_id` = %d
 		/**
 		 * Sets the order-by clause used in the action claim query.
 		 *
-		 * @since 3.4.0
-		 * @since 3.8.3 Made $claim_id and $hooks available.
-		 *
 		 * @param string $order_by_sql
 		 * @param string $claim_id Claim Id.
-		 * @param array  $hooks Hooks to filter for.
+		 * @param array  $hooks    Hooks to filter for.
+		 *
+		 * @since 3.8.3 Made $claim_id and $hooks available.
+		 * @since 3.4.0
 		 */
-		$order           = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
-		$select_params[] = $limit;
+		$order       = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
+		$skip_locked = $this->db_supports_skip_locked() ? ' SKIP LOCKED' : '';
 
 		// Selecting the action_ids that we plan to claim, while skipping any locked rows to avoid deadlocking.
-		$select_sql = $wpdb->prepare( "{$select} {$where} {$order} LIMIT %d FOR UPDATE SKIP LOCKED", $select_params );
+		$select_sql = $wpdb->prepare( "SELECT action_id from {$wpdb->actionscheduler_actions} {$where} {$order} LIMIT %d FOR UPDATE{$skip_locked}", array_merge( $where_params, array( $limit ) ) );
 
 		// Now place it into an UPDATE statement by joining the result sets, allowing for the SKIP LOCKED behavior to take effect.
 		$update_sql    = "UPDATE {$wpdb->actionscheduler_actions} t1 JOIN ( $select_sql ) t2 ON t1.action_id = t2.action_id SET claim_id=%d, last_attempt_gmt=%s, last_attempt_local=%s";
@@ -1019,7 +1016,6 @@ AND `group_id` = %d
 			$error = empty( $wpdb->last_error )
 				? _x( 'unknown', 'database error', 'action-scheduler' )
 				: $wpdb->last_error;
-
 			throw new \RuntimeException(
 				sprintf(
 					/* translators: %s database error. */
@@ -1030,6 +1026,36 @@ AND `group_id` = %d
 		}
 
 		return (int) $rows_affected;
+	}
+
+	/**
+	 * Determines whether the database supports using SKIP LOCKED.
+	 *
+	 * SKIP_LOCKED support was added to MariaDB in 10.6.0 and to MySQL in 8.0.1
+	 *
+	 * @return bool
+	 */
+	private function db_supports_skip_locked() {
+		global $wpdb;
+		$db_version     = $wpdb->db_version();
+		$db_server_info = $wpdb->db_server_info();
+		$is_mariadb     = ( false !== str_contains( $db_server_info, 'MariaDB' ) );
+
+		if ( $is_mariadb &&
+		     '5.5.5' === $db_version &&
+		     PHP_VERSION_ID < 80016 // PHP 8.0.15 or older.
+		) {
+			/*
+			 * Account for MariaDB version being prefixed with '5.5.5-' on older PHP versions.
+			 */
+			$db_server_info = preg_replace( '/^5\.5\.5-(.*)/', '$1', $db_server_info );
+			$db_version     = preg_replace( '/[^0-9.].*/', '', $db_server_info );
+		}
+
+		$is_supported = ( $is_mariadb && version_compare( $db_version, '10.6.0', '>=' ) ) ||
+		                ( ! $is_mariadb && version_compare( $db_version, '8.0.1', '>=' ) );
+
+		return $is_supported;
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1055,7 +1055,14 @@ AND `group_id` = %d
 		$is_supported = ( $is_mariadb && version_compare( $db_version, '10.6.0', '>=' ) ) ||
 		                ( ! $is_mariadb && version_compare( $db_version, '8.0.1', '>=' ) );
 
-		return $is_supported;
+		/**
+		 * Filter whether the database supports the SKIP LOCKED modifier for queries.
+		 *
+		 * @param bool $is_supported Whether SKIP LOCKED is supported.
+		 *
+		 * @since 3.9.3
+		 */
+		return apply_filters( 'action_scheduler_db_supports_skip_locked', $is_supported );
 	}
 
 	/**

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -20,7 +20,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	 *
 	 * @var int
 	 */
-	protected $schema_version = 7;
+	protected $schema_version = 8;
 
 	/**
 	 * Construct.

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -80,7 +80,9 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
-				        KEY `claim_id_status_scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
+				        KEY `claim_id_status_priority_scheduled_date_gmt` (`claim_id`,`status`,`priority`,`scheduled_date_gmt`),
+				        KEY `status_last_attempt_gmt` (`status`,`last_attempt_gmt`),
+				        KEY `status_claim_id` (`status`,`claim_id`)
 				        ) $charset_collate";
 
 			case self::CLAIMS_TABLE:

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -757,7 +757,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( get_class( $wpdb ) )
-		             ->onlyMethods( [ 'db_server_info' ] )
+		             ->setMethods( [ 'db_server_info' ] )
 		             ->getMock();
 		$wpdb->method( 'db_server_info' )->willReturn( $db_server_info );
 
@@ -768,6 +768,11 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertSame( $expected_result, $method->invoke( $db_store ) );
 	}
 
+	/**
+	 * Data Provider for ::test_db_supports_skip_locked().
+	 *
+	 * @return array[]
+	 */
 	public static function db_supports_skip_locked_provider(): array {
 		// PHP <= 8.0.15 didn't strip the 5.5.5- prefix for MariaDB.
 		$maria_db_prefix = PHP_VERSION_ID < 80016 ? '5.5.5-' : '';

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -8,13 +8,35 @@ use Action_Scheduler\Tests\DataStores\AbstractStoreTest;
  */
 class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 
-	public function setUp() {
+	/**
+	 * Saved instance of wpdb to restore in cases where we replace the global instance with a mock.
+	 *
+	 * @see $this->test_db_supports_skip_locked()
+	 *
+	 * @var \wpdb
+	 */
+	private $original_wpdb;
+
+	public function set_up() {
 		global $wpdb;
 
 		// Delete all actions before each test.
 		$wpdb->query( "DELETE FROM {$wpdb->actionscheduler_actions}" );
 
-		parent::setUp();
+		parent::set_up();
+	}
+
+	/**
+	 * Restore the original wpdb global instance for tests that have replaced it.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		global $wpdb;
+		if ( null !== $this->original_wpdb ) {
+			$wpdb                = $this->original_wpdb;
+			$this->original_wpdb = null;
+		}
 	}
 
 	/**
@@ -718,5 +740,67 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		add_action( 'parent', $parent_action );
 
 		$this->assertEquals( range( 1, 20 ), $actual_order, 'Once claimed, scheduled actions are executed in the expected order, including if "child actions" are scheduled from within another action.' );
+	}
+
+	/**
+	 * @param bool   $expected_result
+	 * @param string $db_server_info
+	 *
+	 * @return void
+	 *
+	 * @dataProvider db_supports_skip_locked_provider
+	 */
+	public function test_db_supports_skip_locked( bool $expected_result, string $db_server_info ) {
+		global $wpdb;
+
+		// Stash the original since we're overwriting it with a partial mock. Self::tear_down() will restore this.
+		$this->original_wpdb = $wpdb;
+
+		$wpdb = $this->getMockBuilder( get_class( $wpdb ) )
+		             ->onlyMethods( [ 'db_server_info' ] )
+		             ->getMock();
+		$wpdb->method( 'db_server_info' )->willReturn( $db_server_info );
+
+		$reflection = new \ReflectionClass( ActionScheduler_DBStore::class );
+		$method     = $reflection->getMethod( 'db_supports_skip_locked' );
+		$method->setAccessible( true );
+		$db_store = new ActionScheduler_DBStore();
+		$this->assertSame( $expected_result, $method->invoke( $db_store ) );
+	}
+
+	public static function db_supports_skip_locked_provider(): array {
+		// PHP <= 8.0.15 didn't strip the 5.5.5- prefix for MariaDB.
+		$maria_db_prefix = PHP_VERSION_ID < 80016 ? '5.5.5-' : '';
+
+		return array(
+			'MySQL 5.6.1 does not support skip locked'    => array(
+				false,
+				'5.6.1'
+			),
+			'MySQL 8.0.0 does not support skip locked'    => array(
+				false,
+				'8.0.0'
+			),
+			'MySQL 8.0.1 does support skip locked'        => array(
+				true,
+				'8.0.1'
+			),
+			'MySQL 8.4.4 does support skip locked'        => array(
+				true,
+				'8.4.4'
+			),
+			'MariaDB 10.5.0 does not support skip locked' => array(
+				false,
+				$maria_db_prefix . '10.5.0-MariaDB'
+			),
+			'MariaDB 10.6.0 does support skip locked'     => array(
+				true,
+				$maria_db_prefix . '10.6.0-MariaDB'
+			),
+			'MariaDB 11.5.0 does support skip locked'     => array(
+				true,
+				$maria_db_prefix . '11.5.0-MariaDB'
+			),
+		);
 	}
 }

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -17,13 +17,13 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	 */
 	private $original_wpdb;
 
-	public function set_up() {
+	public function setUp() {
 		global $wpdb;
 
 		// Delete all actions before each test.
 		$wpdb->query( "DELETE FROM {$wpdb->actionscheduler_actions}" );
 
-		parent::set_up();
+		parent::setUp();
 	}
 
 	/**
@@ -31,12 +31,13 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	 *
 	 * @return void
 	 */
-	public function tear_down() {
+	public function tearDown() {
 		global $wpdb;
 		if ( null !== $this->original_wpdb ) {
 			$wpdb                = $this->original_wpdb;
 			$this->original_wpdb = null;
 		}
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -758,7 +758,9 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 
 		$wpdb = $this->getMockBuilder( get_class( $wpdb ) )
 		             ->setMethods( [ 'db_server_info' ] )
+		             ->disableOriginalConstructor()
 		             ->getMock();
+
 		$wpdb->method( 'db_server_info' )->willReturn( $db_server_info );
 
 		$reflection = new \ReflectionClass( ActionScheduler_DBStore::class );

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -449,7 +449,7 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 		$this->assertContains( 'Caught exception while enqueuing action "hook_18": Error saving action', $logged_errors );
 		$this->assertContains( 'Caught exception while enqueuing action "hook_19": Error saving action', $logged_errors );
 		$this->assertContains( 'Caught exception while enqueuing action "hook_20": Error saving action', $logged_errors );
-		$this->assertContains( "Unknown column 'priority' in 'field list'", $logged_errors );
+		$this->assertContains( "Unknown column 'priority' in ", $logged_errors );
 
 		// recreate the priority column.
 		$wpdb->query( "ALTER TABLE {$wpdb->actionscheduler_actions} ADD COLUMN priority tinyint(10) UNSIGNED NOT NULL DEFAULT 10" );


### PR DESCRIPTION
### Avoiding SQL deadlocks during action claiming

When running multiple action scheduler queues concurrently, many will start to fatal error due to SQL deadlocks. I have found that this always stems from the action claims query. This query ends up scanning many rows, and being an UPDATE, it ends up creating locks on the table/rows. This results in concurrent claims queries conflicting with each other and deadlocking. It also causes deadlocks during individual action status updates from other queues that are already processing actions. This leaves actions in unknown states and results in lots needing to be failed later on due to timeouts during the cleanup periods.

This PR prevents the deadlocks altogether. The magic here comes from the `SKIP LOCKED` SQL feature: https://dev.mysql.com/blog-archive/mysql-8-0-1-using-skip-locked-and-nowait-to-handle-hot-rows/. It's a perfect fit for the claims query, because we don't really care if it needs to skip over a few rows. All we want is for it to claim actions without conflict.

The `SKIP LOCKED` has to come from a SELECT query. So the new query here uses a SELECT sub-query (w/ `FOR UPDATE` to claim a lock) and then JOINs the results to accomplish first selecting the items and then updating them all within a single transaction.

I've done a lot of testing with this and ran into no deadlocks or failing actions. I've run hundreds of thousands of actions at 250 queue concurrency without any signs of trouble.

```
BEFORE (causes deadlocks):

UPDATE wp_actionscheduler_actions SET claim_id=4322, last_attempt_gmt='2025-01-15 03:24:52', last_attempt_local='2025-01-14 21:24:53' WHERE claim_id = 0 AND scheduled_date_gmt <= '2025-01-15 03:23:18' AND status='pending' ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT 20;

AFTER (no deadlocks):

UPDATE wp_actionscheduler_actions t1 JOIN ( SELECT action_id from wp_actionscheduler_actions WHERE claim_id = 0 AND scheduled_date_gmt <= '2025-01-15 03:24:52' AND status='pending' ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT 20 FOR UPDATE SKIP LOCKED ) t2 ON t1.action_id = t2.action_id SET claim_id=4322, last_attempt_gmt='2025-01-15 03:24:52', last_attempt_local='2025-01-14 21:24:53';
```

### Considerations

I'm not necessarily suggesting we merge this PR as is (leaving as a draft for now), but I wanted to show the solution here and what I've found. We'll need to test and discover database compatibility before shipping this as the new default behavior.

`SKIP LOCKED` shipped with MySQL 8.0.1 (2017-04-10) and MariaDB in 10.6.0 (2021-4-26), and works only for InnoDB tables (ignored otherwise). I've only done the testing in MySQL only, and I'm not sure if it's safely ignored on the older versions or if it would cause issues.

I do think this would definitely be a worthwhile change to get into the plugin, as I've seen it be a source of a lot of issues. Some possible rollout options:

A) Put it into a new method (`claim_actions_v2()`), and use the new method when a feature flag is present via some constant or filter.
B) Check the database version, and automatically use the v2 method when it's modern enough.