### PR TITLE
Add hook specifically for scheduling recurring actions.

### DIFF
--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Class ActionScheduler_RecurringActionScheduler
+ *
+ * This class ensures that the `action_scheduler_schedule_recurring_actions` hook is triggered on a daily interval. This
+ * simplifies the process for other plugins to register their recurring actions without requiring each plugin to query
+ * or schedule actions independently on every request.
+ */
+class ActionScheduler_RecurringActionScheduler {
+
+	/**
+	 * Initialize the instance.  Should only be run on a single instance per request.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
+			add_action( 'action_scheduler_init', [ __CLASS__, 'schedule_recurring_scheduler_hook' ] );
+		}
+	}
+
+	/**
+	 * Schedule the recurring `action_scheduler_schedule_recurring_actions` action if not already scheduled.
+	 *
+	 * @return void
+	 */
+	public function schedule_recurring_scheduler_hook(): void {
+		if ( false === wp_cache_get( 'as_is_recurring_scheduler_scheduled' ) ) {
+			if ( ! as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ) ) {
+				as_schedule_recurring_action(
+					time(),
+					DAY_IN_SECONDS, // Hourly interval
+					'action_scheduler_schedule_recurring_actions',
+					[],
+					'ActionScheduler',
+					true,
+					20
+				);
+			}
+			wp_cache_set( 'as_is_recurring_scheduler_scheduled', true, HOUR_IN_SECONDS );
+		}
+	}
+}

--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -10,13 +10,22 @@
 class ActionScheduler_RecurringActionScheduler {
 
 	/**
+	 * @var string The hook of the scheduled recurring action that is run to trigger the
+	 *      `action_scheduler_schedule_recurring_actions` hook that plugins should use.  We can't directly have the
+	 *      scheduled action hook be the hook plugins should use because the actions will show as failed if no plugin
+	 *      was actively hooked into it.
+	 */
+	private const RUN_SCHEDULED_RECURRING_ACTIONS_HOOK = 'action_scheduler_run_recurring_actions_schedule_hook';
+
+	/**
 	 * Initialize the instance.  Should only be run on a single instance per request.
 	 *
 	 * @return void
 	 */
 	public function init(): void {
+		add_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK, array( $this, 'run_recurring_scheduler_hook' ) );
 		if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
-			add_action( 'action_scheduler_init', [ __CLASS__, 'schedule_recurring_scheduler_hook' ] );
+			add_action( 'action_scheduler_init', array( $this, 'schedule_recurring_scheduler_hook' ) );
 		}
 	}
 
@@ -27,11 +36,11 @@ class ActionScheduler_RecurringActionScheduler {
 	 */
 	public function schedule_recurring_scheduler_hook(): void {
 		if ( false === wp_cache_get( 'as_is_recurring_scheduler_scheduled' ) ) {
-			if ( ! as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ) ) {
+			if ( ! as_has_scheduled_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK ) ) {
 				as_schedule_recurring_action(
 					time(),
 					DAY_IN_SECONDS, // Hourly interval
-					'action_scheduler_schedule_recurring_actions',
+					self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK,
 					[],
 					'ActionScheduler',
 					true,
@@ -40,5 +49,14 @@ class ActionScheduler_RecurringActionScheduler {
 			}
 			wp_cache_set( 'as_is_recurring_scheduler_scheduled', true, HOUR_IN_SECONDS );
 		}
+	}
+
+	/**
+	 * Trigger the hook to allow other plugins to schedule their recurring actions.
+	 *
+	 * @return void
+	 */
+	public function run_recurring_scheduler_hook(): void {
+		do_action( 'action_scheduler_schedule_recurring_actions' );
 	}
 }

--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -3,7 +3,7 @@
 /**
  * Class ActionScheduler_RecurringActionScheduler
  *
- * This class ensures that the `action_scheduler_schedule_recurring_actions` hook is triggered on a daily interval. This
+ * This class ensures that the `action_scheduler_ensure_recurring_actions` hook is triggered on a daily interval. This
  * simplifies the process for other plugins to register their recurring actions without requiring each plugin to query
  * or schedule actions independently on every request.
  */
@@ -11,7 +11,7 @@ class ActionScheduler_RecurringActionScheduler {
 
 	/**
 	 * @var string The hook of the scheduled recurring action that is run to trigger the
-	 *      `action_scheduler_schedule_recurring_actions` hook that plugins should use.  We can't directly have the
+	 *      `action_scheduler_ensure_recurring_actions` hook that plugins should use.  We can't directly have the
 	 *      scheduled action hook be the hook plugins should use because the actions will show as failed if no plugin
 	 *      was actively hooked into it.
 	 */
@@ -30,16 +30,16 @@ class ActionScheduler_RecurringActionScheduler {
 	}
 
 	/**
-	 * Schedule the recurring `action_scheduler_schedule_recurring_actions` action if not already scheduled.
+	 * Schedule the recurring `action_scheduler_ensure_recurring_actions` action if not already scheduled.
 	 *
 	 * @return void
 	 */
 	public function schedule_recurring_scheduler_hook(): void {
-		if ( false === wp_cache_get( 'as_is_recurring_scheduler_scheduled' ) ) {
+		if ( false === wp_cache_get( 'as_is_ensure_recurring_actions_scheduled' ) ) {
 			if ( ! as_has_scheduled_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK ) ) {
 				as_schedule_recurring_action(
 					time(),
-					DAY_IN_SECONDS, // Hourly interval
+					DAY_IN_SECONDS,
 					self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK,
 					[],
 					'ActionScheduler',
@@ -47,7 +47,7 @@ class ActionScheduler_RecurringActionScheduler {
 					20
 				);
 			}
-			wp_cache_set( 'as_is_recurring_scheduler_scheduled', true, HOUR_IN_SECONDS );
+			wp_cache_set( 'as_is_ensure_recurring_actions_scheduled', true, HOUR_IN_SECONDS );
 		}
 	}
 
@@ -57,6 +57,25 @@ class ActionScheduler_RecurringActionScheduler {
 	 * @return void
 	 */
 	public function run_recurring_scheduler_hook(): void {
-		do_action( 'action_scheduler_schedule_recurring_actions' );
+		/**
+		 * Fires to allow extensions to verify and ensure their recurring actions are scheduled.
+		 *
+		 * This action is scheduled to trigger once every 24 hrs for the purpose of having 3rd party plugins verify that
+		 * any previously scheduled recurring actions are still scheduled. Because recurring actions could stop getting
+		 * rescheduled by default due to excessive failures, database issues, or other interruptions, extensions can use
+		 * this hook to check for the existence of their recurring actions and reschedule them if necessary.
+		 *
+		 * Example usage:
+		 *
+		 * add_action('action_scheduler_ensure_recurring_actions', function() {
+		 *     // Check if the recurring action is scheduled, and reschedule if missing.
+		 *     if ( ! as_has_scheduled_action('my_recurring_action') ) {
+		 *         as_schedule_recurring_action( time(), HOUR_IN_SECONDS, 'my_recurring_action' );
+		 *     }
+		 * });
+		 *
+		 * @since 3.9.3
+		 */
+		do_action( 'action_scheduler_ensure_recurring_actions' );
 	}
 }

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -184,10 +184,11 @@ abstract class ActionScheduler {
 		require_once self::plugin_path( 'functions.php' );
 		ActionScheduler_DataController::init();
 
-		$store      = self::store();
-		$logger     = self::logger();
-		$runner     = self::runner();
-		$admin_view = self::admin_view();
+		$store                      = self::store();
+		$logger                     = self::logger();
+		$runner                     = self::runner();
+		$admin_view                 = self::admin_view();
+		$recurring_action_scheduler = new ActionScheduler_RecurringActionScheduler();
 
 		// Ensure initialization on plugin activation.
 		if ( ! did_action( 'init' ) ) {
@@ -196,6 +197,7 @@ abstract class ActionScheduler {
 			add_action( 'init', array( $store, 'init' ), 1, 0 );
 			add_action( 'init', array( $logger, 'init' ), 1, 0 );
 			add_action( 'init', array( $runner, 'init' ), 1, 0 );
+			add_action( 'init', array( $recurring_action_scheduler, 'init' ) );
 
 			add_action(
 				'init',
@@ -223,6 +225,7 @@ abstract class ActionScheduler {
 			$store->init();
 			$logger->init();
 			$runner->init();
+			$recurring_action_scheduler->init();
 			self::$data_store_initialized = true;
 
 			/**

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -197,7 +197,7 @@ abstract class ActionScheduler {
 			add_action( 'init', array( $store, 'init' ), 1, 0 );
 			add_action( 'init', array( $logger, 'init' ), 1, 0 );
 			add_action( 'init', array( $runner, 'init' ), 1, 0 );
-			add_action( 'init', array( $recurring_action_scheduler, 'init' ) );
+			add_action( 'init', array( $recurring_action_scheduler, 'init' ), 1, 0 );
 
 			add_action(
 				'init',

--- a/docs/api.md
+++ b/docs/api.md
@@ -251,3 +251,38 @@ as_get_scheduled_actions( $args, $return_format );
 ### Return value
 
 `(array)` Array of action rows matching the criteria specified with `$args`.
+
+## Function Reference / `as_supports()`
+
+### Description
+
+Check if a specific feature is supported by the current version of Action Scheduler.
+
+*Available since 3.9.3.*
+
+### Usage
+
+```php
+as_supports( $feature );
+```
+
+### Parameters
+
+**$feature** (string) (required)  
+The feature to check support for.  
+Currently supported:
+- `'ensure_recurring_actions_hook'` — Indicates support for the `action_scheduler_ensure_recurring_actions` hook.
+
+### Return value
+
+`(boolean)`  
+True if the feature is supported, false otherwise.
+
+### Example
+
+```php
+if ( as_supports( 'ensure_recurring_actions_hook' ) ) {
+    // Safe to depend on the 'action_scheduler_ensure_recurring_actions' hook.
+    add_action( 'action_scheduler_ensure_recurring_actions', 'my_plugin_schedule_my_recurring_action' );
+}
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,36 +96,93 @@ Action Scheduler will later initialize itself on `'init'` with priority `1`.  Ac
 
 When using Action Scheduler in themes, it's important to note that if Action Scheduler has been registered by a plugin, then the latest version registered by a plugin will be used, rather than the version included in the theme. This is because of the version dependency handling code using `'plugins_loaded'` since version 1.0.
 
-## Scheduling an Action
+## Scheduling Recurring Actions on Activation and Ensuring They Remain Scheduled
 
-To schedule an action, call the [API function](/api/) for the desired schedule type passing in the required parameters.
+When developing a plugin or extension that relies on recurring actions, it is essential to schedule those actions when the plugin is first activated or updated.
 
-The example code below shows everything needed to schedule a function to run at midnight, if it's not already scheduled:
+### Best Practice: Schedule on Activation
 
+Plugins should always schedule any important recurring actions during activation or upgrade routines. This ensures the action is registered as soon as the plugin is enabled.
+
+**Example: Scheduling on Activation**
 ```php
-require_once( plugin_dir_path( __FILE__ ) . '/libraries/action-scheduler/action-scheduler.php' );
-
 /**
- * Schedule an action with the hook 'eg_midnight_log' to run at midnight each day
- * so that our callback is run then.
+ * Schedule recurring action on plugin activation.
  */
-function eg_schedule_midnight_log() {
-	if ( false === as_has_scheduled_action( 'eg_midnight_log' ) ) {
-		as_schedule_recurring_action( strtotime( 'tomorrow' ), DAY_IN_SECONDS, 'eg_midnight_log', array(), '', true );
-	}
+function my_plugin_activate() {
+    if ( ! as_has_scheduled_action( 'my_plugin_recurring_action' ) ) {
+        as_schedule_recurring_action(
+            time(),
+            HOUR_IN_SECONDS,
+            'my_plugin_recurring_action'
+        );
+    }
 }
-add_action( 'init', 'eg_schedule_midnight_log' );
-
-/**
- * A callback to run when the 'eg_midnight_log' scheduled action is run.
- */
-function eg_log_action_data() {
-	error_log( 'It is just after midnight on ' . date( 'Y-m-d' ) );
-}
-add_action( 'eg_midnight_log', 'eg_log_action_data' );
+register_activation_hook( __FILE__, 'my_plugin_activate' );
 ```
 
-Note that the `as_has_scheduled_action()` function was added in 3.3.0: if you are using an earlier version, you should use `as_next_scheduled_action()` instead. For more details on all available API functions, and the data they accept, refer to the [API Reference](/api/).
+### Ensuring Recurring Actions Remain Scheduled
+
+After initial scheduling, there may be rare cases where a recurring action is lost (e.g., due to a database failure or repeated action failures). The `action_scheduler_ensure_recurring_actions` hook provides a reliable opportunity to check and reschedule the action if necessary. 
+
+**Example: Using the Ensure Hook**
+```php
+/**
+ * Ensure recurring action remains scheduled.
+ */
+add_action( 'action_scheduler_ensure_recurring_actions', function() {
+    if ( ! as_has_scheduled_action( 'my_plugin_recurring_action' ) ) {
+        as_schedule_recurring_action(
+            time(),
+            HOUR_IN_SECONDS,
+            'my_plugin_recurring_action'
+        );
+    }
+});
+```
+
+### Compatibility Notes:
+
+When using Action Scheduler, be aware of version-specific features and functions. If your plugin may run with older versions of Action Scheduler because it is relying on ActionScheduler to be included separately from your plugin where you cannot be sure of the version being loaded, use the following guidance to ensure compatibility.
+ 
+**New in 3.9.3: `action_scheduler_ensure_recurring_actions` Hook and `as_supports()`**
+* The `action_scheduler_ensure_recurring_actions` hook and the `as_supports()` API method were introduced in Action Scheduler 3.9.3.
+* To use this hook, first check that the current Action Scheduler version supports it.  
+
+**Example: Ensuring a Recurring Action Remains Scheduled in a Backward Compatible Way**
+```php
+/**
+ * Schedules the plugin's recurring action if it is not already scheduled.
+ */
+function my_plugin_schedule_my_recurring_action() {
+	if ( ! as_has_scheduled_action( 'my_plugin_recurring_action' ) ) {
+		as_schedule_recurring_action(
+			time(),
+			HOUR_IN_SECONDS,
+			'my_plugin_recurring_action'
+		);
+	}
+}
+
+/**
+ * Add the hooks needed for my_plugin_schedule_my_recurring_action() so it can make sure our hook stays scheduled.
+ */
+add_action( 'init', function () {
+	if ( function_exists( 'as_supports' ) && as_supports( 'ensure_recurring_actions_hook' ) ) {
+		// Preferred: runs periodically in the background.
+		add_action( 'action_scheduler_ensure_recurring_actions', 'my_plugin_schedule_my_recurring_action' );
+	} elseif ( is_admin() ) {
+		// Fallback: runs on every admin request.
+		my_plugin_schedule_my_recurring_action();
+	}
+} );
+```
+
+**Note on `as_has_scheduled_action()` (Added in 3.3.0)**
+*	The `as_has_scheduled_action()` function was introduced in Action Scheduler 3.3.0.
+*	If you need to support even older versions, check if the `as_has_scheduled_action` function exists and fallback to `as_next_scheduled_action()` instead.
+
+For more details on all available API functions, their parameters, and when they were added, refer to the [API Reference](https://actionscheduler.org/api/).
 
 ### Passing arguments
 

--- a/functions.php
+++ b/functions.php
@@ -493,3 +493,16 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
 	}
 	return $date;
 }
+
+/**
+ * Check if a specific feature is supported by the current version of Action Scheduler.
+ *
+ * @param string $feature The feature to check support for.
+ *
+ * @return bool True if the feature is supported, false otherwise.
+ */
+function as_supports( string $feature ): bool {
+	$supported_features = array( 'schedule_recurring_actions_hook' );
+
+	return in_array( $feature, $supported_features, true );
+}

--- a/functions.php
+++ b/functions.php
@@ -497,12 +497,14 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
 /**
  * Check if a specific feature is supported by the current version of Action Scheduler.
  *
+ * @since 3.9.3
+ *
  * @param string $feature The feature to check support for.
  *
  * @return bool True if the feature is supported, false otherwise.
  */
 function as_supports( string $feature ): bool {
-	$supported_features = array( 'schedule_recurring_actions_hook' );
+	$supported_features = array( 'ensure_recurring_actions_hook' );
 
 	return in_array( $feature, $supported_features, true );
 }

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -30,6 +30,7 @@
 			<directory>./phpunit/versioning</directory>
 			<file>./phpunit/logging/ActionScheduler_wpCommentLogger_Test.php</file>
 			<file>./phpunit/jobstore/ActionScheduler_wpPostStore_Test.php</file>
+			<file>./phpunit/jobstore/ActionScheduler_RecurringActionScheduler_Test.php</file>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/tests/phpunit/ActionScheduler_RecurringActionScheduler_Test.php
+++ b/tests/phpunit/ActionScheduler_RecurringActionScheduler_Test.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Test suite for the ActionScheduler_RecurringActionScheduler class.
+ */
+class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_UnitTestCase {
+
+	public function tear_down() {
+		wp_cache_delete( 'as_is_recurring_scheduler_scheduled' );
+		as_unschedule_action( 'action_scheduler_schedule_recurring_actions' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that the init method hooks into 'action_scheduler_init' correctly.
+	 */
+	public function test_init_hooks_into_action_scheduler_init() {
+		global $current_screen;
+
+		$scheduler = new ActionScheduler_RecurringActionScheduler();
+		$scheduler->init();
+
+		// Only apply hooks when in the admin.
+		$_current_screen = $current_screen;
+		set_current_screen( 'dashboard' );
+
+		try {
+			// Verify that the 'action_scheduler_init' hook is registered with the correct callback
+			$this->assertTrue(
+				has_action( 'action_scheduler_init', array(
+					ActionScheduler_RecurringActionScheduler::class,
+					'schedule_recurring_scheduler_hook'
+				) ) > 0,
+				'The schedule_recurring_scheduler_hook method should be hooked into action_scheduler_init.'
+			);
+		} finally {
+			// Clean up to avoid affecting any other tests.
+			$current_screen = $_current_screen;
+			remove_action(
+				'action_scheduler_init',
+				array(
+					ActionScheduler_RecurringActionScheduler::class,
+					'schedule_recurring_scheduler_hook'
+				)
+			);
+		}
+	}
+
+	/**
+	 * Test that schedule_recurring_scheduler_hook schedules the recurring action when not already scheduled.
+	 */
+	public function test_schedule_recurring_scheduler_hook_schedules_action() {
+		// Ensure no action is scheduled initially
+		$this->assertFalse(
+			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			'No recurring action should be scheduled initially.'
+		);
+
+		$scheduler = new ActionScheduler_RecurringActionScheduler();
+		$scheduler->schedule_recurring_scheduler_hook();
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			'The recurring action should now be scheduled.'
+		);
+	}
+
+	/**
+	 * Test that schedule_recurring_scheduler_hook respects caching and does not schedule actions redundantly.
+	 */
+	public function test_schedule_recurring_scheduler_hook__respects_cache() {
+		// Ensure no action is scheduled initially
+		$this->assertFalse(
+			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			'No recurring action should be scheduled initially.'
+		);
+
+		// Simulate a cache hit
+		wp_cache_set( 'as_is_recurring_scheduler_scheduled', true, '', HOUR_IN_SECONDS );
+
+		// Spy on as_schedule_recurring_action to verify it does NOT get called
+		$scheduler = new ActionScheduler_RecurringActionScheduler();
+		$scheduler->schedule_recurring_scheduler_hook();
+
+		// Assert that no new action was scheduled due to cache hit
+		$this->assertFalse(
+			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			'No new recurring action should be scheduled due to cache hit.'
+		);
+	}
+}

--- a/tests/phpunit/ActionScheduler_RecurringActionScheduler_Test.php
+++ b/tests/phpunit/ActionScheduler_RecurringActionScheduler_Test.php
@@ -7,7 +7,7 @@ class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_Unit
 
 	public function tear_down() {
 		wp_cache_delete( 'as_is_recurring_scheduler_scheduled' );
-		as_unschedule_action( 'action_scheduler_schedule_recurring_actions' );
+		as_unschedule_action( 'action_scheduler_ensure_recurring_actions' );
 
 		parent::tear_down();
 	}
@@ -53,7 +53,7 @@ class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_Unit
 	public function test_schedule_recurring_scheduler_hook_schedules_action() {
 		// Ensure no action is scheduled initially
 		$this->assertFalse(
-			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			as_has_scheduled_action( 'action_scheduler_ensure_recurring_actions' ),
 			'No recurring action should be scheduled initially.'
 		);
 
@@ -61,7 +61,7 @@ class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_Unit
 		$scheduler->schedule_recurring_scheduler_hook();
 
 		$this->assertTrue(
-			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			as_has_scheduled_action( 'action_scheduler_ensure_recurring_actions' ),
 			'The recurring action should now be scheduled.'
 		);
 	}
@@ -72,7 +72,7 @@ class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_Unit
 	public function test_schedule_recurring_scheduler_hook__respects_cache() {
 		// Ensure no action is scheduled initially
 		$this->assertFalse(
-			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			as_has_scheduled_action( 'action_scheduler_ensure_recurring_actions' ),
 			'No recurring action should be scheduled initially.'
 		);
 
@@ -85,7 +85,7 @@ class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_Unit
 
 		// Assert that no new action was scheduled due to cache hit
 		$this->assertFalse(
-			as_has_scheduled_action( 'action_scheduler_schedule_recurring_actions' ),
+			as_has_scheduled_action( 'action_scheduler_ensure_recurring_actions' ),
 			'No new recurring action should be scheduled due to cache hit.'
 		);
 	}

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -462,7 +462,7 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 	 * Test that as_supports returns true for supported features.
 	 */
 	public function test_as_supports_for_supported_feature() {
-		$this->assertTrue( as_supports( 'schedule_recurring_actions_hook' ) );
+		$this->assertTrue( as_supports( 'ensure_recurring_actions_hook' ) );
 	}
 
 	/**

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -459,6 +459,20 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	/**
+	 * Test that as_supports returns true for supported features.
+	 */
+	public function test_as_supports_for_supported_feature() {
+		$this->assertTrue( as_supports( 'schedule_recurring_actions_hook' ) );
+	}
+
+	/**
+	 * Test that as_supports returns false for unsupported features.
+	 */
+	public function test_as_supports_for_unsupported_feature() {
+		$this->assertFalse( as_supports( 'non_existent_feature' ) );
+	}
+
+	/**
 	 * Helper method to set actions scheduler store.
 	 *
 	 * @param ActionScheduler_Store $store Store instance to set.


### PR DESCRIPTION
# Changes proposed in this Pull Request

This is an upstream implementation of https://github.com/woocommerce/woocommerce/pull/56380.

The goal of this change is to provide a hook for other plugins and extensions to use specifically for ensuring that recurring actions are scheduled.

## The Problem

The current documentation for scheduling a recurring action is as follows:

```
/**
 * Schedule an action with the hook 'eg_midnight_log' to run at midnight each day
 * so that our callback is run then.
 */
function eg_schedule_midnight_log() {
	if ( false === as_has_scheduled_action( 'eg_midnight_log' ) ) {
		as_schedule_recurring_action( strtotime( 'tomorrow' ), DAY_IN_SECONDS, 'eg_midnight_log', array(), '', true );
	}
}
add_action( 'init', 'eg_schedule_midnight_log' );
```

Ideally, the inner part of the `eg_schedule_midnight_log()` function above would only be run during certain events like plugin activation or updates, however, there are environments where the activation/update flow are not used or crash scenarios could cause a recurring action to not get properly rescheduled.  So, the above pattern is used to guarantee those recurring actions required by the plugin are and stay scheduled.

There are some performance problems with this in that `as_has_scheduled_action( 'eg_midnight_log' )` requires a query to be run on every request and while this is mostly a high performant query, having every plugin run it for all of their scheduled recurring actions can add a bit of overhead to a request.

## Proposed Solution

This PR introduces a new hook called `action_scheduler_schedule_recurring_actions` that plugins should start using in order to schedule recurring actions.  This specific implementation schedules a new recurring action just to run this recurring hook - the idea being that one implementation with controlled best practices on when it checks to see if it is scheduled is better than each plugin doing it itself.

# New Proposed Integration

```php
function eg_schedule_midnight_log() {
	if ( false === as_has_scheduled_action( 'eg_midnight_log' ) ) {
		as_schedule_recurring_action( strtotime( 'tomorrow' ), DAY_IN_SECONDS, 'eg_midnight_log', array(), '', true );
	}
}

/**
 * If you plugin includes ActionScheduler and therefore knows that the version supports the
 * `action_scheduler_schedule_recurring_actions` hook, you can simply use
 */
add_action( 'action_scheduler_schedule_recurring_actions', 'eg_schedule_midnight_log' );

/**
 * If your plugin does not package ActionScheduler and is unsure if the `action_scheduler_schedule_recurring_actions` hook
 * is supported, use the following:
 */
if ( function_exists( 'as_supports' ) && as_supports( 'schedule_recurring_actions_hook' ) ) {
	add_action( 'action_scheduler_schedule_recurring_actions', 'eg_schedule_midnight_log' );
} else {
	add_action( 'action_scheduler_init', 'eg_schedule_midnight_log' );
}
```

# Testing Instructions

1. Go to WP-Admin -> Tools -> Scheduled Actions
2. You should be able to find an action scheduled with the hook of 'action_scheduler_run_recurring_actions_schedule_hook'
3. Add a snippet similar to the following somewhere on the site:
 ```php
 add_action( 'init', function () {
	add_action( 'action_scheduler_schedule_recurring_actions', function () {
		if ( ! as_has_scheduled_action( 'my_random_callback_action' ) ) {
			as_schedule_recurring_action( time(), 5 * MINUTE_IN_SECONDS, 'my_random_callback_action' );
		}
	} );
} );

add_action( 'my_random_callback_action', function () {
	error_log( 'IT WORKED!!!!!!!' );
} );
 ```
 4. Run the `action_scheduler_run_recurring_actions_schedule_hook` action by hovering over it and clicking `Run` (otherwise you'd have to wait up to 24 hours).
  ![Screenshot 2025-04-09 at 1 04 36 PM](https://github.com/user-attachments/assets/25a279ff-c1ef-42d5-b6ca-dec5cb0c5a76)
5. You should immediately see the `my_random_callback_action` Action scheduled as a new recurring action and checking your error log should show the `IT WORKED!!!!!!!` text.