### PR TITLE
Make `$unique` available to all pre-creation/short-circuit hooks.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -86,8 +86,9 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 	 * @param array    $args       Action arguments.
 	 * @param string   $group      Action group.
 	 * @param int      $priorities Action priority.
+	 * @param bool     $unique     Unique action.
 	 */
-	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group, $priority );
+	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group, $priority, $unique );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}
@@ -159,8 +160,9 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	 * @param array    $args                Action arguments.
 	 * @param string   $group               Action group.
 	 * @param int      $priority            Action priority.
+	 * @param bool     $unique              Unique action.
 	 */
-	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group, $priority );
+	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group, $priority, $unique );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}
@@ -225,8 +227,9 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 	 * @param array    $args       Action arguments.
 	 * @param string   $group      Action group.
 	 * @param int      $priority   Action priority.
+	 * @param bool     $unique     Unique action.
 	 */
-	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group, $priority );
+	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group, $priority, $unique );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}


### PR DESCRIPTION
Makes `$unique` available to consumers of the following filter hooks:

- `pre_as_schedule_single_action`
- `pre_as_schedule_recurring_action`
- `pre_as_schedule_cron_action`

#### Why is this needed?

Unique actions *('there should be only one')* have been a feature of Action Scheduler since the 3.6.0 release. 

However, currently, callbacks using any of the three hooks above will not be able to tell if an action should be unique or not ... in some cases this may lead to them (re-)creating the actions as if they were non-unique. This is quite risky—please refer back to [this historic issue](https://github.com/woocommerce/action-scheduler/issues/1023) (which was [partly solved already](https://github.com/woocommerce/action-scheduler/pull/1039), though we didn't think about this specific dimension at the time).

#### Testing

Code review is probably sufficient here. We're supplying an additional param to the hooks, but are not changing the order of the params—so existing consumers should be unaffected. 

That said, you can simulate the problem and see the change by running through the following steps. Start by checking out this branch and then add the following code (I'm using PHP 8 syntax for readability, please adapt as needed if you are using an older version) to a mu-plugin or other suitable location. Note that, initially, we only accept 7 params, so the callback is unaware of whether or not an action should be unique. This lets us simulate the problem:

```php
add_filter(
	'pre_as_schedule_recurring_action',
	function ( $short_circuit, $timestamp, $interval_in_seconds, $hook, $args, $group, $priority ) {
		static $lock = false;

		// Prevent infinite loops of doom 🧙‍♂️
		if ( $lock ) {
			return $short_circuit;
		}

		$lock   = true;
		$result = as_schedule_recurring_action(
			timestamp:           $timestamp,
			interval_in_seconds: $interval_in_seconds,
			hook:                $hook,
			args:                $args,
			group:               $group,
			priority:            $priority,
		);
		$lock   = false;

		return $result;
	},
	10,
	7
);
```

Try creating a *unique* recurring action. Via WP CLI:

```
wp eval "as_schedule_recurring_action( time() + 600, HOUR_IN_SECONDS, 'test_action', [], '', true );"
```

Do this three times, then run:

```
wp action-scheduler action list --hook=test_action
```

You should see that we have three of these test actions. This is wrong/bad/risky, because the action is intended to be unique (there should only ever be one pending instance):

```
% wp action-scheduler action list --hook=test_action
                                                
+--------+-------------+---------+-------+-----------+---------------------------+
| id     | hook        | status  | group | recurring | scheduled_date            |
+--------+-------------+---------+-------+-----------+---------------------------+
| 665969 | test_action | pending |       | yes       | 2025-04-11 18:25:16 +0000 |
| 665972 | test_action | pending |       | yes       | 2025-04-11 18:30:59 +0000 |
| 665974 | test_action | pending |       | yes       | 2025-04-11 18:31:32 +0000 |
+--------+-------------+---------+-------+-----------+---------------------------+
```

Now modify the snippet to the following (this demonstrates the fix):

```php
add_filter(
	'pre_as_schedule_recurring_action',
	function ( $short_circuit, $timestamp, $interval_in_seconds, $hook, $args, $group, $priority, $unique ) {
		static $lock = false;

		// Prevent infinite loops of doom 🧙‍♂️
		if ( $lock ) {
			return $short_circuit;
		}

		$lock   = true;
		$result = as_schedule_recurring_action(
			timestamp:           $timestamp,
			interval_in_seconds: $interval_in_seconds,
			hook:                $hook,
			args:                $args,
			group:               $group,
			priority:            $priority,
			unique:              $unique,
		);
		$lock   = false;

		return $result;
	},
	10,
	8
);
```

Repeat the test. No further actions should be created (uniqueness is now respected). If you wish, you can now switch to a different hook name and verify that the creation of *new* unique actions is not impeeded:

```
% wp eval "as_schedule_recurring_action( time() + 600, HOUR_IN_SECONDS, 'test_action2', [], '', true );"
% wp eval "as_schedule_recurring_action( time() + 600, HOUR_IN_SECONDS, 'test_action2', [], '', true );"
% wp action-scheduler action list --hook=test_action2     
                                              
+--------+--------------+---------+-------+-----------+---------------------------+
| id     | hook         | status  | group | recurring | scheduled_date            |
+--------+--------------+---------+-------+-----------+---------------------------+
| 665977 | test_action2 | pending |       | yes       | 2025-04-11 18:43:54 +0000 |
+--------+--------------+---------+-------+-----------+---------------------------+
```

Closes #1263

### Changelog

> Dev - Makes the `$unique` param available via the `pre_as_schedule_*_action` hooks.