### PR TITLE
Import `get_flag_value()` from `WP_CLI\Utils` before using.

### DIFF
--- a/classes/WP_CLI/Action/Create_Command.php
+++ b/classes/WP_CLI/Action/Create_Command.php
@@ -2,6 +2,8 @@
 
 namespace Action_Scheduler\WP_CLI\Action;
 
+use function \WP_CLI\Utils\get_flag_value;
+
 /**
  * WP-CLI command: action-scheduler action create
  */


### PR DESCRIPTION
As identified in the linked issue, we are attempting to use a namespaced function without importing or fully qualifying it, leading to a fatal error when attempting to create an action via WP CLI.

Closes #1270.

---

### Steps to replicate

- Using the current stable release (3.9.2), try running `wp action-scheduler create test now` and you will experience a fatal error.
- Switch to this branch and repeat the test. The action should successfully be created.

### Changelog

> Fixed fatal error occuring when creating an action via WP CLI.