### PR TITLE
WP CLI get action command: correct parentheses/nesting of conditional checks.

### DIFF
--- a/classes/WP_CLI/Action/Get_Command.php
+++ b/classes/WP_CLI/Action/Get_Command.php
@@ -24,7 +24,7 @@ class Get_Command extends \ActionScheduler_WPCLI_Command {
 		}
 
 		$only_logs   = ! empty( $this->assoc_args['field'] ) && 'log_entries' === $this->assoc_args['field'];
-		$only_logs   = $only_logs || ( ! empty( $this->assoc_args['fields'] && 'log_entries' === $this->assoc_args['fields'] ) );
+		$only_logs   = $only_logs || ( ! empty( $this->assoc_args['fields'] ) && 'log_entries' === $this->assoc_args['fields'] );
 		$log_entries = array();
 
 		foreach ( $logger->get_logs( $action_id ) as $log_entry ) {


### PR DESCRIPTION
When looking at https://github.com/woocommerce/action-scheduler/pull/1271, I noticed a problem with the `wp action-scheduler action get <id>` command. This command was mostly functional, but also generated a warning relating to its handling of the `--fields` flag:

```
PHP Warning:  Undefined array key "fields" in /.../wp-content/plugins/action-scheduler/classes/WP_CLI/Action/Get_Command.php on line 27
```

The problem was a small oversight in the line used to check if this flag was set.

---

### Steps to replicate

1. First, identify an existing scheduled action and note down the ID.
    1. An easy way to do this is to run `wp action-scheduler action list` and grab the first ID.
    2. In the event you don't have any actions, you can generate one with `wp eval "as_enqueue_async_action( 'test' );"` (or else you can use `wp action-scheduler action create test now` once https://github.com/woocommerce/action-scheduler/pull/1271 has been merged).
2. Using the current stable release (3.9.2), try running `wp action-scheduler action get <ID>` and you should see the same error noted in the PR description.
3. Switch to this branch and repeat, the error should be solved.
4. Confirm that the `--fields` flag still works as expected by running `wp action-scheduler action get <ID> --fields=hook,status`.

### Changelog

> Fixes a problem with `wp action-scheduler action get` and its handling of the `--fields` flag.