### PR TITLE
Fix possible undefined variable in `action cancel --all` CLI command

### DIFF
--- a/classes/WP_CLI/Action/Cancel_Command.php
+++ b/classes/WP_CLI/Action/Cancel_Command.php
@@ -79,7 +79,7 @@ class Cancel_Command extends \ActionScheduler_WPCLI_Command {
 		try {
 			$result = as_unschedule_all_actions( $hook, $callback_args, $group );
 		} catch ( \Exception $e ) {
-			$this->print_error( $e, $multiple );
+			$this->print_error( $e, true );
 		}
 
 		/**


### PR DESCRIPTION
This PR addresses a possible warning when an error occurs while processing the `wp action-scheduler action cancel --all` command.

Closes #1268.


### Testing Instructions
1. Temporarily enable the following snippet on your site to simulate an error occurring while bulk-canceling actions:
   ```php
   <?php
   add_action(
       'action_scheduler_bulk_cancel_actions',
       function() {
           throw new \Exception( 'Some error' );
       }
   );
   ```
1. Run the following commands:
   ```
   $ wp action-scheduler action create myhook async
   $ wp action-scheduler action cancel myhook --all
   ```
1. Confirm no new PHP warning is logged.
1. (Optional) Repeat the above on `trunk` and confirm that the following error appears in your logs:
   > PHP Warning:  Undefined variable $multiple in /[...]/action-scheduler/classes/WP_CLI/Action/Cancel_Command.php on line 82