### PR TITLE
Move recurring A-S cache key to transient

### DIFF
--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -35,7 +35,7 @@ class ActionScheduler_RecurringActionScheduler {
 	 * @return void
 	 */
 	public function schedule_recurring_scheduler_hook(): void {
-		if ( false === wp_cache_get( 'as_is_ensure_recurring_actions_scheduled' ) ) {
+		if ( false === wp_cache_get( 'as_is_ensure_recurring_actions_scheduled', 'ActionScheduler' ) ) {
 			if ( ! as_has_scheduled_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK ) ) {
 				as_schedule_recurring_action(
 					time(),

--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -47,7 +47,7 @@ class ActionScheduler_RecurringActionScheduler {
 					20
 				);
 			}
-			wp_cache_set( 'as_is_ensure_recurring_actions_scheduled', true, HOUR_IN_SECONDS );
+			wp_cache_set( 'as_is_ensure_recurring_actions_scheduled', true, 'ActionScheduler', HOUR_IN_SECONDS );
 		}
 	}
 

--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -35,7 +35,7 @@ class ActionScheduler_RecurringActionScheduler {
 	 * @return void
 	 */
 	public function schedule_recurring_scheduler_hook(): void {
-		if ( false === wp_cache_get( 'as_is_ensure_recurring_actions_scheduled', 'ActionScheduler' ) ) {
+		if ( false === get_transient( 'as_is_ensure_recurring_actions_scheduled' ) ) {
 			if ( ! as_has_scheduled_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK ) ) {
 				as_schedule_recurring_action(
 					time(),
@@ -47,7 +47,7 @@ class ActionScheduler_RecurringActionScheduler {
 					20
 				);
 			}
-			wp_cache_set( 'as_is_ensure_recurring_actions_scheduled', true, 'ActionScheduler', HOUR_IN_SECONDS );
+			set_transient( 'as_is_ensure_recurring_actions_scheduled', true, HOUR_IN_SECONDS );
 		}
 	}
 

--- a/tests/phpunit/ActionScheduler_RecurringActionScheduler_Test.php
+++ b/tests/phpunit/ActionScheduler_RecurringActionScheduler_Test.php
@@ -6,7 +6,7 @@
 class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_UnitTestCase {
 
 	public function tear_down() {
-		wp_cache_delete( 'as_is_recurring_scheduler_scheduled' );
+		delete_transient( 'as_is_ensure_recurring_actions_scheduled' );
 		as_unschedule_action( 'action_scheduler_ensure_recurring_actions' );
 
 		parent::tear_down();
@@ -76,17 +76,17 @@ class ActionScheduler_RecurringActionScheduler_Test extends ActionScheduler_Unit
 			'No recurring action should be scheduled initially.'
 		);
 
-		// Simulate a cache hit
-		wp_cache_set( 'as_is_recurring_scheduler_scheduled', true, '', HOUR_IN_SECONDS );
+		// Simulate a transient hit
+		set_transient( 'as_is_ensure_recurring_actions_scheduled', true, HOUR_IN_SECONDS );
 
 		// Spy on as_schedule_recurring_action to verify it does NOT get called
 		$scheduler = new ActionScheduler_RecurringActionScheduler();
 		$scheduler->schedule_recurring_scheduler_hook();
 
-		// Assert that no new action was scheduled due to cache hit
+		// Assert that no new action was scheduled due to transient hit
 		$this->assertFalse(
 			as_has_scheduled_action( 'action_scheduler_ensure_recurring_actions' ),
-			'No new recurring action should be scheduled due to cache hit.'
+			'No new recurring action should be scheduled due to transient hit.'
 		);
 	}
 }


### PR DESCRIPTION
In #1260 we introduced a standard hook for the scheduling of recurring actions, which is triggered once per day. The scheduling of this once per day action is "protected" by a cache key which was meant to have an expiration of 1 hour, but due to a possible typo in #1260, ended up with no expiration.

This PR ensures that the data truly expires every hour and also moves this from using the object cache to a transient.

Closes #1296.


### Testing Instructions
1. Check out this branch and load any admin page.
1. Confirm that `wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending` returns one job.
1. Confirm that the transient has been set:
   ```
   wp transient get as_is_ensure_recurring_actions_scheduled 
   ```
1. Remove scheduled instances of the "ensure recurring" job:
   ```
   wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending --format=ids | xargs wp action-scheduler action delete
   ```

   Confirm that it was indeed deleted, by running `wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending` again. No results should be returned.
1. Load any admin page again, and ensure that this doesn't re-schedule the "ensure recurring" job: `wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending` should return no results.
1. "Simulate" the transient expiration by manually removing it:
   ```
   wp transient delete as_is_ensure_recurring_actions_scheduled
   ```
1. Load any admin page again.
1. Confirm that the "ensure recurring" job was re-scheduled: `wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending` should return a result.