### PR TITLE
Make unique action inserts atomic

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.2.0 - xxxx-xx-xx =
+* Fix - Enforce unique action inserts atomically and release stale uniqueness keys during scheduled cleanup.
+
 = 4.1.0 - 2026-08-05 =
 * Fix - Correct an oversight in the lock implementation (used to rate-limit async request runners) that could leave a lock permanently stuck and result in database errors in unusual cases.
 * Fix - Correct the behavior of the `wp action-scheduler clean` command so that the `--before` option defaults to 31 days ago.

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -142,14 +142,18 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 				$data['extended_args'] = $args;
 			}
 
+			if ( $unique && self::STATUS_PENDING === $data['status'] ) {
+				$data['unique_key'] = $this->get_unique_action_key( $action );
+			}
+
 			$insert_sql = $this->build_insert_sql( $data, $unique );
 
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $insert_sql should be already prepared.
-			$wpdb->query( $insert_sql );
-			$action_id = $wpdb->insert_id;
+			$query_result = $wpdb->query( $insert_sql );
+			$action_id    = $wpdb->insert_id;
 
-			if ( is_wp_error( $action_id ) ) {
-				throw new \RuntimeException( $action_id->get_error_message() );
+			if ( false === $query_result ) {
+				throw new \RuntimeException( $wpdb->last_error ? $wpdb->last_error : __( 'Database error.', 'action-scheduler' ) );
 			} elseif ( empty( $action_id ) ) {
 				if ( $unique ) {
 					return 0;
@@ -186,13 +190,15 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$column_sql      = '`' . implode( '`, `', $columns ) . '`';
 		$placeholder_sql = implode( ', ', $placeholders );
 		$where_clause    = $this->build_where_clause_for_insert( $data, $table_name, $unique );
+		$conflict_clause = $unique ? 'ON DUPLICATE KEY UPDATE `unique_key` = VALUES(`unique_key`)' : '';
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare	 -- $column_sql and $where_clause are already prepared. $placeholder_sql is hardcoded.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare	 -- $column_sql and $where_clause are already prepared. $placeholder_sql and $conflict_clause are hardcoded.
 		$insert_query = $wpdb->prepare(
 			"
 INSERT INTO $table_name ( $column_sql )
 SELECT $placeholder_sql FROM DUAL
-WHERE ( $where_clause ) IS NULL",
+WHERE ( $where_clause ) IS NULL
+$conflict_clause",
 			$values
 		);
 		// phpcs:enable
@@ -263,9 +269,36 @@ AND args = %s
 			'last_attempt_gmt',
 			'last_attempt_local',
 			'extended_args',
+			'unique_key',
 		);
 
 		return in_array( $column_name, $string_columns, true ) ? '%s' : '%d';
+	}
+
+	/**
+	 * Generate the versioned identity key for a unique action.
+	 *
+	 * Scheduling details and priority are intentionally excluded to preserve the existing uniqueness contract.
+	 *
+	 * @param ActionScheduler_Action $action Action object.
+	 * @return string
+	 * @throws \RuntimeException If the action identity cannot be encoded.
+	 */
+	private function get_unique_action_key( ActionScheduler_Action $action ) {
+		$identity = wp_json_encode(
+			array(
+				'hook'  => $action->get_hook(),
+				'args'  => $action->get_args(),
+				'group' => $action->get_group(),
+			)
+		);
+
+		if ( false === $identity ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new \RuntimeException( __( 'Unable to generate a unique action key.', 'action-scheduler' ) );
+		}
+
+		return 'v1:' . hash( 'sha256', $identity );
 	}
 
 	/**
@@ -766,9 +799,12 @@ AND args = %s
 
 		$updated = $wpdb->update(
 			$wpdb->actionscheduler_actions,
-			array( 'status' => self::STATUS_CANCELED ),
+			array(
+				'status'     => self::STATUS_CANCELED,
+				'unique_key' => null,
+			),
 			array( 'action_id' => $action_id ),
-			array( '%s' ),
+			array( '%s', '%s' ),
 			array( '%d' )
 		);
 		if ( false === $updated ) {
@@ -849,7 +885,7 @@ AND args = %s
 
 			$wpdb->query(
 				$wpdb->prepare(
-					"UPDATE {$wpdb->actionscheduler_actions} SET status = %s WHERE action_id IN {$query_in}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"UPDATE {$wpdb->actionscheduler_actions} SET status = %s, unique_key = NULL WHERE action_id IN {$query_in}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					$parameters
 				)
 			);
@@ -1312,9 +1348,10 @@ AND args = %s
 				'status'             => self::STATUS_FAILED,
 				'last_attempt_gmt'   => current_time( 'mysql', true ),
 				'last_attempt_local' => current_time( 'mysql' ),
+				'unique_key'         => null,
 			),
 			array( 'action_id' => $action_id ),
-			array( '%s', '%s', '%s' ),
+			array( '%s', '%s', '%s', '%s' ),
 			array( '%d' )
 		);
 		if ( empty( $updated ) ) {
@@ -1380,9 +1417,10 @@ AND args = %s
 				'status'             => self::STATUS_COMPLETE,
 				'last_attempt_gmt'   => current_time( 'mysql', true ),
 				'last_attempt_local' => current_time( 'mysql' ),
+				'unique_key'         => null,
 			),
 			array( 'action_id' => $action_id ),
-			array( '%s', '%s', '%s' ),
+			array( '%s', '%s', '%s', '%s' ),
 			array( '%d' )
 		);
 		if ( empty( $updated ) ) {

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -63,6 +63,57 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$table_maker = new ActionScheduler_StoreSchema();
 		$table_maker->init();
 		$table_maker->register_tables();
+
+		add_action( 'action_scheduler_run_actions_cleanup_hook', array( $this, 'release_stale_unique_action_keys' ), 10, 0 );
+		add_action( 'action_scheduler_continue_actions_cleanup_hook', array( $this, 'release_stale_unique_action_keys' ), 10, 0 );
+	}
+
+	/**
+	 * Release keys left behind by custom terminal-status transitions, without deleting action history.
+	 *
+	 * @internal
+	 * @return void
+	 * @throws RuntimeException When stale keys cannot be released.
+	 */
+	public function release_stale_unique_action_keys() {
+		global $wpdb;
+
+		$released = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->actionscheduler_actions}
+				SET unique_key = NULL
+				WHERE status IN (%s, %s, %s) AND unique_key IS NOT NULL
+				ORDER BY action_id
+				LIMIT 1000",
+				self::STATUS_COMPLETE,
+				self::STATUS_FAILED,
+				self::STATUS_CANCELED
+			)
+		);
+
+		if ( false === $released ) {
+			throw new RuntimeException( 'Unable to release stale unique action keys: ' . esc_html( $wpdb->last_error ) );
+		}
+
+		if ( 1000 !== $released ) {
+			return;
+		}
+
+		$continuation_hook = 'action_scheduler_continue_actions_cleanup_hook';
+		$called_from_run   = doing_action( 'action_scheduler_run_actions_cleanup_hook' );
+		$pending           = as_get_scheduled_actions(
+			array(
+				'hook'     => $continuation_hook,
+				'status'   => self::STATUS_PENDING,
+				'per_page' => 1,
+			),
+			'ids'
+		);
+
+		// A running continuation must not prevent another batch from being scheduled.
+		if ( empty( $pending ) ) {
+			as_schedule_single_action( time(), $continuation_hook, array(), 'ActionScheduler', $called_from_run, 0 );
+		}
 	}
 
 	/**

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -20,7 +20,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	 *
 	 * @var int
 	 */
-	protected $schema_version = 8;
+	protected $schema_version = 9;
 
 	/**
 	 * Construct.
@@ -73,7 +73,9 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        last_attempt_local datetime NULL default '{$default_date}',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
+				        unique_key varchar(191) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
+				        UNIQUE KEY unique_key (unique_key),
 				        KEY hook_status_scheduled_date_gmt (hook($hook_status_scheduled_date_gmt_max_index_length), status, scheduled_date_gmt),
 				        KEY status_scheduled_date_gmt (status, scheduled_date_gmt),
 				        KEY scheduled_date_gmt (scheduled_date_gmt),

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -671,6 +671,189 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	}
 
 	/**
+	 * Test that the unique action key column is nullable and database-enforced.
+	 */
+	public function test_unique_action_key_schema() {
+		global $wpdb;
+
+		$column = $wpdb->get_row( "SHOW COLUMNS FROM {$wpdb->actionscheduler_actions} LIKE 'unique_key'", ARRAY_A );
+		$index  = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->actionscheduler_actions} WHERE Key_name = 'unique_key'", ARRAY_A );
+
+		$this->assertNotNull( $column );
+		$this->assertSame( 'YES', $column['Null'] );
+		$this->assertNull( $column['Default'] );
+		$this->assertNotNull( $index );
+		$this->assertSame( '0', $index['Non_unique'] );
+	}
+
+	/**
+	 * Test that non-unique actions leave the unique key empty.
+	 */
+	public function test_non_unique_action_does_not_store_unique_key() {
+		global $wpdb;
+
+		$time      = as_get_datetime_object();
+		$schedule  = new ActionScheduler_SimpleSchedule( $time );
+		$store     = new ActionScheduler_DBStore();
+		$action    = new ActionScheduler_Action( md5( wp_rand() ), array(), $schedule );
+		$action_id = $store->save_action( $action );
+
+		$this->assertNull(
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT unique_key FROM {$wpdb->actionscheduler_actions} WHERE action_id = %d",
+					$action_id
+				)
+			)
+		);
+	}
+
+	/**
+	 * Test that the database constraint rejects an insert even when the lookup cannot see the conflicting active action.
+	 */
+	public function test_unique_action_key_is_enforced_at_database_boundary() {
+		global $wpdb;
+
+		$time       = as_get_datetime_object();
+		$hook       = md5( wp_rand() );
+		$schedule   = new ActionScheduler_SimpleSchedule( $time );
+		$store      = new ActionScheduler_DBStore();
+		$action     = new ActionScheduler_Action( $hook, array( 'foo' => 'bar' ), $schedule, 'my_group' );
+		$action_id  = $store->save_unique_action( $action );
+		$unique_key = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT unique_key FROM {$wpdb->actionscheduler_actions} WHERE action_id = %d",
+				$action_id
+			)
+		);
+
+		$this->assertNotEmpty( $unique_key );
+
+		// Hide the row from the active-action lookup while retaining its key, simulating a competing insert after lookup.
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array( 'status' => ActionScheduler_Store::STATUS_COMPLETE ),
+			array( 'action_id' => $action_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		$this->assertSame( 0, $store->save_unique_action( $action ) );
+		$this->assertSame(
+			'1',
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$wpdb->actionscheduler_actions} WHERE unique_key = %s",
+					$unique_key
+				)
+			)
+		);
+	}
+
+	/**
+	 * Test that an in-progress action retains its key and continues blocking duplicates.
+	 */
+	public function test_in_progress_unique_action_retains_key() {
+		global $wpdb;
+
+		$time       = as_get_datetime_object();
+		$hook       = md5( wp_rand() );
+		$schedule   = new ActionScheduler_SimpleSchedule( $time );
+		$store      = new ActionScheduler_DBStore();
+		$action     = new ActionScheduler_Action( $hook, array(), $schedule );
+		$action_id  = $store->save_unique_action( $action );
+		$unique_key = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT unique_key FROM {$wpdb->actionscheduler_actions} WHERE action_id = %d",
+				$action_id
+			)
+		);
+
+		$store->log_execution( $action_id );
+
+		$this->assertNotEmpty( $unique_key );
+		$this->assertSame(
+			$unique_key,
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT unique_key FROM {$wpdb->actionscheduler_actions} WHERE action_id = %d",
+					$action_id
+				)
+			)
+		);
+		$this->assertSame( 0, $store->save_unique_action( $action ) );
+	}
+
+	/**
+	 * Test that terminal status transitions release the unique key.
+	 *
+	 * @dataProvider terminal_status_transition_provider
+	 *
+	 * @param string $transition Store method used to move the action to a terminal status.
+	 */
+	public function test_terminal_status_releases_unique_action_key( $transition ) {
+		global $wpdb;
+
+		$time      = as_get_datetime_object();
+		$hook      = md5( wp_rand() );
+		$schedule  = new ActionScheduler_SimpleSchedule( $time );
+		$store     = new ActionScheduler_DBStore();
+		$action    = new ActionScheduler_Action( $hook, array(), $schedule );
+		$action_id = $store->save_unique_action( $action );
+
+		$store->$transition( $action_id );
+
+		$this->assertNull(
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT unique_key FROM {$wpdb->actionscheduler_actions} WHERE action_id = %d",
+					$action_id
+				)
+			)
+		);
+		$this->assertNotSame( 0, $store->save_unique_action( $action ) );
+	}
+
+	/**
+	 * Terminal status transitions that must release an action's unique key.
+	 *
+	 * @return array[]
+	 */
+	public function terminal_status_transition_provider() {
+		return array(
+			'completed' => array( 'mark_complete' ),
+			'failed'    => array( 'mark_failure' ),
+			'canceled'  => array( 'cancel_action' ),
+		);
+	}
+
+	/**
+	 * Test that bulk cancellation releases unique keys.
+	 */
+	public function test_bulk_cancel_releases_unique_action_key() {
+		global $wpdb;
+
+		$time      = as_get_datetime_object();
+		$hook      = md5( wp_rand() );
+		$schedule  = new ActionScheduler_SimpleSchedule( $time );
+		$store     = new ActionScheduler_DBStore();
+		$action    = new ActionScheduler_Action( $hook, array(), $schedule );
+		$action_id = $store->save_unique_action( $action );
+
+		$store->cancel_actions_by_hook( $hook );
+
+		$this->assertNull(
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT unique_key FROM {$wpdb->actionscheduler_actions} WHERE action_id = %d",
+					$action_id
+				)
+			)
+		);
+		$this->assertNotSame( 0, $store->save_unique_action( $action ) );
+	}
+
+	/**
 	 * When a set of claimed actions are processed, they should be executed in the expected order (by priority,
 	 * then by least number of attempts, then by scheduled date, then finally by action ID).
 	 *

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -828,6 +828,136 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	}
 
 	/**
+	 * Scheduled cleanup repairs terminal rows without deleting their history.
+	 */
+	public function test_scheduled_cleanup_releases_stale_unique_action_keys() {
+		global $wpdb;
+
+		$store    = new ActionScheduler_DBStore();
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object() );
+		$actions  = array();
+		$statuses = array( ActionScheduler_Store::STATUS_COMPLETE, ActionScheduler_Store::STATUS_FAILED, ActionScheduler_Store::STATUS_CANCELED );
+		$store->init();
+
+		foreach ( $statuses as $status ) {
+			$action    = new ActionScheduler_Action( 'stale_unique_' . $status, array(), $schedule );
+			$action_id = $store->save_unique_action( $action );
+			// Simulate an older store override that updates the status without releasing the key.
+			$wpdb->update(
+				$wpdb->actionscheduler_actions,
+				array(
+					'status'           => $status,
+					'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s' ),
+				),
+				array( 'action_id' => $action_id )
+			);
+			$this->assertSame( 0, $store->save_unique_action( $action ) );
+			$actions[ $action_id ] = $action;
+		}
+
+		do_action( 'action_scheduler_run_actions_cleanup_hook' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks -- Invoke an existing hook, not a new declaration.
+
+		foreach ( $actions as $action_id => $action ) {
+			$this->assertNotSame( 0, $store->save_unique_action( $action ) );
+			$this->assertContains( $store->get_status( $action_id ), $statuses, 'Cleanup must retain action history.' );
+		}
+	}
+
+	/**
+	 * Cleanup must not release keys belonging to pending or running actions.
+	 */
+	public function test_scheduled_cleanup_preserves_active_unique_action_keys() {
+		$store    = new ActionScheduler_DBStore();
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object() );
+		$pending  = new ActionScheduler_Action( 'pending_unique_cleanup', array(), $schedule );
+		$running  = new ActionScheduler_Action( 'running_unique_cleanup', array(), $schedule );
+		$store->init();
+
+		$pending_id = $store->save_unique_action( $pending );
+		$running_id = $store->save_unique_action( $running );
+		$store->log_execution( $running_id );
+
+		do_action( 'action_scheduler_run_actions_cleanup_hook' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks -- Invoke an existing hook, not a new declaration.
+
+		$this->assertSame( 0, $store->save_unique_action( $pending ) );
+		$this->assertSame( 0, $store->save_unique_action( $running ) );
+		$this->assertSame( ActionScheduler_Store::STATUS_PENDING, $store->get_status( $pending_id ) );
+		$this->assertSame( ActionScheduler_Store::STATUS_RUNNING, $store->get_status( $running_id ) );
+	}
+
+	/**
+	 * Bounded cleanup continues past a running batch and reuses a pending continuation.
+	 */
+	public function test_stale_unique_key_cleanup_continues_while_cleanup_is_running() {
+		global $wpdb;
+
+		$store             = new ActionScheduler_DBStore();
+		$continuation_hook = 'action_scheduler_continue_actions_cleanup_hook';
+		$running_id        = as_schedule_single_action( time(), $continuation_hook, array(), 'ActionScheduler', true, 0 );
+		ActionScheduler::store()->log_execution( $running_id );
+
+		$values = array();
+		for ( $i = 0; $i < 2001; $i++ ) {
+			$values[] = $wpdb->prepare( '(%s, %s, %s, %s)', 'stale_cleanup_batch', ActionScheduler_Store::STATUS_COMPLETE, 'stale-' . $i, gmdate( 'Y-m-d H:i:s' ) );
+		}
+		$wpdb->query( "INSERT INTO {$wpdb->actionscheduler_actions} (hook, status, unique_key, last_attempt_gmt) VALUES " . implode( ', ', $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		// Execute only this store callback, retaining WordPress's running-hook context.
+		$callbacks = clone $GLOBALS['wp_filter'][ $continuation_hook ];
+		remove_all_actions( $continuation_hook );
+		add_action( $continuation_hook, array( $store, 'release_stale_unique_action_keys' ), 10, 0 );
+		try {
+			do_action( $continuation_hook ); // phpcs:ignore WooCommerce.Commenting.CommentHooks -- Invoke an existing hook, not a new declaration.
+		} finally {
+			$GLOBALS['wp_filter'][ $continuation_hook ] = $callbacks; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the callbacks isolated by this test.
+		}
+
+		$remaining_sql = "SELECT COUNT(*) FROM {$wpdb->actionscheduler_actions} WHERE hook = 'stale_cleanup_batch' AND unique_key IS NOT NULL";
+		$this->assertSame( '1001', $wpdb->get_var( $remaining_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$pending_query = array(
+			'hook'     => $continuation_hook,
+			'status'   => ActionScheduler_Store::STATUS_PENDING,
+			'per_page' => 10,
+		);
+		$pending       = as_get_scheduled_actions( $pending_query, 'ids' );
+		$this->assertCount( 1, $pending, 'A running continuation must allow the next batch.' );
+
+		$store->release_stale_unique_action_keys();
+		$this->assertSame( '1', $wpdb->get_var( $remaining_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$this->assertSame( $pending, as_get_scheduled_actions( $pending_query, 'ids' ), 'Reuse an already pending continuation.' );
+
+		$store->release_stale_unique_action_keys();
+		$this->assertSame( '0', $wpdb->get_var( $remaining_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$this->assertSame( '2001', $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_actions} WHERE hook = 'stale_cleanup_batch'" ) );
+		$this->assertSame( ActionScheduler_Store::STATUS_RUNNING, ActionScheduler::store()->get_status( $running_id ) );
+	}
+
+	/**
+	 * A failed update must not schedule another cleanup batch.
+	 */
+	public function test_stale_unique_key_cleanup_reports_database_failure() {
+		global $wpdb;
+
+		$original_wpdb                 = $wpdb;
+		$wpdb                          = $this->getMockBuilder( wpdb::class )->disableOriginalConstructor()->onlyMethods( array( 'query', 'prepare' ) )->getMock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Simulate a database failure without damaging the test schema.
+		$wpdb->actionscheduler_actions = $original_wpdb->actionscheduler_actions;
+		$wpdb->last_error              = 'Cleanup test failure';
+		$wpdb->expects( $this->once() )->method( 'query' )->willReturn( false );
+		$wpdb->method( 'prepare' )->willReturnCallback( array( $original_wpdb, 'prepare' ) );
+
+		try {
+			( new ActionScheduler_DBStore() )->release_stale_unique_action_keys();
+			$this->fail( 'A failed update must be reported.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Unable to release stale unique action keys: Cleanup test failure', $exception->getMessage() );
+		} finally {
+			$wpdb = $original_wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the database connection after the simulated failure.
+		}
+
+		$this->assertFalse( as_has_scheduled_action( 'action_scheduler_continue_actions_cleanup_hook' ) );
+	}
+
+	/**
 	 * Test that bulk cancellation releases unique keys.
 	 */
 	public function test_bulk_cancel_releases_unique_action_key() {


### PR DESCRIPTION
## What

Fixes #1317.

Unique actions currently use a lookup followed by an insert. Concurrent
requests can both pass that lookup and create duplicates.

This change:

- adds a nullable `unique_key` column with a database unique index;
- increments the store schema to version 9 so existing rows receive `NULL`;
- generates a versioned `v1:` identity from the hook, exact arguments, and
  group slug;
- retains the existing lookup so an active non-unique action still blocks a
  matching unique action;
- handles an atomic key conflict as the existing `0` result without masking
  unrelated database errors; and
- releases the key when an action completes, fails, or is canceled, while
  retaining it for pending and in-progress actions.

Schedule type, timestamp, and priority are intentionally excluded from the
identity, preserving the current hook + args + group uniqueness contract.
Using the group slug instead of its database ID also keeps the identity stable
if concurrent requests create the same previously unseen group.

## Review follow-up and compatibility

The existing daily cleanup now releases stale keys on completed, failed and
canceled actions in batches of 1,000. This recovers from custom terminal-status
transitions that bypass normal key release, without deleting action history
or clearing pending/running keys. A full batch reuses the existing cleanup
continuation; a running continuation does not prevent its successor.

Cleanup database errors are logged without throwing, so other hook handlers
can continue. When a unique insert returns the atomic conflict/no-op result,
the store clears only that identity's terminal key and retries once if a key
was released. Pending/running actions stay protected, including a competing
insert between recovery and retry. This path uses the affected-row result
because `ON DUPLICATE KEY UPDATE` does not produce a duplicate-key SQL error.

Existing method signatures, abstract store requirements and hook arguments
are unchanged. The new internal public DBStore callback,
`release_stale_unique_action_keys()`, is additive; subclasses already using
that name should be checked for declaration compatibility. Custom cleaners
that replace the existing scheduled hooks still need their own recovery.

Queries use the current registered site table. Single-site and multisite
bootstrap tests pass; explicit cross-blog switching and large-table/concurrent
runner stress testing were not performed. This follow-up adds no further
schema revision. Deadlock handling and recurring-action uniqueness remain
outside scope.

## Validation

Latest local validation against upstream `6f49ea8` on September 14:

- New stale-key regressions were written failing-first.
- Immediate recovery, interleaved competitor and cleanup-error hook coverage:
  30 tests, 48 assertions, in multisite; each also passed in single-site.
- DBStore and QueueCleaner: 492 tests, 536 assertions.
- Remaining suite excluding the recurring-scheduler baseline class:
  1,806 tests, 1,884 assertions, zero failures and ten existing PHPUnit warnings.
- Changed-line PHPCS, PHP syntax and `git diff --check` pass.
- Runtime: WordPress 7.0.1, PHP 8.3, PHPUnit 8.5.52, MySQL 9.6.0.

The unfiltered suite (1,824 tests, 1,894 assertions) has four failures in
`ActionScheduler_RecurringActionScheduler_Test`; the same failures reproduce
on clean upstream `d12d6ef` in a separate fresh database during the previous
validation. Upstream changes since that baseline affect only the admin Screen
Option and changelog, not the failing scheduler paths. Earlier validation of
the original insert change also confirmed the nullable unique index and
schema version 9 on MariaDB 10.4.
