### PR TITLE
Fix screen options on WooCommerce status page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 4.1.0 - xxxx-xx-xx =
+* Fix - Show the per-page Screen Option on WooCommerce's Scheduled Actions tab.
 * Use `wp_admin_notice()` to render admin notices, instead of custom HTML.
 * Fix an oversight in the lock implementation (used to rate-limit async request runners) that could result in a database error in unusual cases.
 * Add protections to guard against the risk of object-injection/deserialization attacks when retrieving stored schedule data.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.2.0 - xxxx-xx-xx =
+* Fix - Show the per-page Screen Option on WooCommerce's Scheduled Actions tab.
+
 = 4.1.0 - 2026-08-05 =
 * Fix - Correct an oversight in the lock implementation (used to rate-limit async request runners) that could leave a lock permanently stuck and result in database errors in unusual cases.
 * Fix - Correct the behavior of the `wp action-scheduler clean` command so that the `--before` option defaults to 31 days ago.

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -53,6 +53,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
 
 			if ( class_exists( 'WooCommerce' ) ) {
+				add_action( 'load-woocommerce_page_wc-status', array( $this, 'maybe_process_wc_admin_ui' ) );
 				add_action( 'woocommerce_admin_status_content_action-scheduler', array( $this, 'render_admin_ui' ) );
 				add_action( 'woocommerce_system_status_report', array( $this, 'system_status_report' ) );
 				add_filter( 'woocommerce_admin_status_tabs', array( $this, 'register_system_status_tab' ) );
@@ -108,6 +109,17 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	 */
 	public function process_admin_ui() {
 		$this->get_list_table();
+	}
+
+	/**
+	 * Initialize the list table early on WooCommerce's Scheduled Actions tab.
+	 */
+	public function maybe_process_wc_admin_ui() {
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( 'action-scheduler' === $tab ) {
+			$this->process_admin_ui();
+		}
 	}
 
 	/**

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -53,6 +53,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
 
 			if ( class_exists( 'WooCommerce' ) ) {
+				add_action( 'load-woocommerce_page_wc-status', array( $this, 'maybe_process_wc_admin_ui' ) );
 				add_action( 'woocommerce_admin_status_content_action-scheduler', array( $this, 'render_admin_ui' ) );
 				add_action( 'woocommerce_system_status_report', array( $this, 'system_status_report' ) );
 				add_filter( 'woocommerce_admin_status_tabs', array( $this, 'register_system_status_tab' ) );
@@ -108,6 +109,17 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	 */
 	public function process_admin_ui() {
 		$this->get_list_table();
+	}
+
+	/**
+	 * Initialize the list table early on WooCommerce's Scheduled Actions tab.
+	 */
+	public function maybe_process_wc_admin_ui() {
+		$tab = isset( $_REQUEST['tab'] ) ? sanitize_key( wp_unslash( $_REQUEST['tab'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( 'action-scheduler' === $tab ) {
+			$this->process_admin_ui();
+		}
 	}
 
 	/**

--- a/tests/phpunit/ActionScheduler_AdminView_Test.php
+++ b/tests/phpunit/ActionScheduler_AdminView_Test.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Tests for the Action Scheduler admin view.
+ */
+class ActionScheduler_AdminView_Test extends ActionScheduler_UnitTestCase {
+
+	public function tearDown(): void {
+		unset( $_GET['tab'] );
+		parent::tearDown();
+	}
+
+	public function test_processes_wc_scheduled_actions_tab() {
+		$_GET['tab'] = 'action-scheduler';
+		$admin_view  = $this->getMockBuilder( ActionScheduler_AdminView::class )
+			->onlyMethods( array( 'process_admin_ui' ) )
+			->getMock();
+
+		$admin_view->expects( $this->once() )->method( 'process_admin_ui' );
+		$admin_view->maybe_process_wc_admin_ui();
+	}
+
+	public function test_ignores_other_wc_status_tabs() {
+		$_GET['tab'] = 'logs';
+		$admin_view  = $this->getMockBuilder( ActionScheduler_AdminView::class )
+			->onlyMethods( array( 'process_admin_ui' ) )
+			->getMock();
+
+		$admin_view->expects( $this->never() )->method( 'process_admin_ui' );
+		$admin_view->maybe_process_wc_admin_ui();
+	}
+}


### PR DESCRIPTION
## Summary
- Initialize the list table early on the WooCommerce Scheduled Actions tab.
- Show the existing per-page Screen Option there.

Addresses part of #1261.

## Screenshots
### Before

<img width="1367" height="437" alt="image" src="https://github.com/user-attachments/assets/c02bf847-f235-4e46-a845-792ca188b516" />

### After

<img width="1512" height="544" alt="image" src="https://github.com/user-attachments/assets/24939d64-802a-4bb0-962b-e9cb2270d5ff" />

## Backward compatibility

Assessed, and considered acceptable.

* **New public method on an overridable class.** `ActionScheduler_AdminView::maybe_process_wc_admin_ui()` is new. Sites can replace that class through the `action_scheduler_admin_view_class` filter, so a third-party subclass could already declare a method of the same name — which would then silently become the override, or fatal on an incompatible signature. The name is specific enough that a collision is very unlikely, and the method is additive: no existing method, signature, or hook changed.
* **No new capability surface.** `load-woocommerce_page_wc-status` fires only after WooCommerce's own `manage_woocommerce` check for that page. The list table was already constructed on the same page by `woocommerce_admin_status_content_action-scheduler`, so this only moves the work earlier in the request.
* **Behavior change, and an improvement.** Row and bulk actions on the Scheduled Actions tab now run before output starts, so the `wp_safe_redirect()` in `ActionScheduler_Abstract_ListTable::process_actions()` works. Previously it ran after the headers were sent. Nonce checks are unchanged (`check_admin_referer()` for bulk actions, `wp_verify_nonce()` for row actions).
* **No change** to the public `as_*()` functions, to any hook we fire, to the stored data or schema, or to the Tools > Scheduled Actions screen.
