### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Full history so phpcs-changed can diff against the base branch.
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
@@ -52,7 +52,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
## Changes proposed in this pull request

Pin every third-party GitHub Action used by this repository to a full 40-character commit SHA. The prior human-readable tag or branch is retained in an inline comment so future updates remain understandable.

The WooCommerce organization intends to enforce full-length commit SHA pinning for Actions at the organization level. Landing this change first avoids disrupting this repository when enforcement is enabled. Immutable action revisions reduce the risk that a moved or compromised upstream tag can be used for a CI/CD supply-chain exploit.

## How to test

- Confirm each external `uses:` reference ends in a 40-character commit SHA.
- Confirm the prior version or branch appears in the inline comment.
- Parse all changed workflow and action metadata files as YAML.
- Re-run the repository audit and confirm it reports zero unpinned external action references.

## Changelog

No changelog entry is needed because this only hardens CI configuration and does not change the shipped product.

_Drafted with AI assistance._
