### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   prep:
     if: ${{ inputs.step == 'release prep' }}
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -225,6 +226,7 @@ jobs:
 
   release:
     if: ${{ inputs.step == 'release' }}
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
 
   release:
     if: ${{ inputs.step == 'release' }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `release.yml` / `prep` | 0.28 min | 0.32 min | 5 |
| `release.yml` / `release` | 0.94 min | 1.37 min | 15 |

The `release` job deploys to WordPress.org over SVN, so it gets headroom above its measured maximum.

Part of TESTOPS-272