### PR TITLE
Pin woo-product-deploy action dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: woocommerce/woo-product-deploy
-          ref: 8b790ecbac9e38798c44c31a5ae9747345efbfff # trunk @ 2026-06-15
+          ref: 1f35b88631478d8f57aa454f81363bb7eed309d3 # trunk @ 2026-08-24
           path: woo-product-deploy
           token: ${{ secrets.ORG_DEPLOY_SECRET }}
           sparse-checkout: .github/workflows/bin
@@ -266,7 +266,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: woocommerce/woo-product-deploy
-          ref: 8b790ecbac9e38798c44c31a5ae9747345efbfff # trunk @ 2026-06-15
+          ref: 1f35b88631478d8f57aa454f81363bb7eed309d3 # trunk @ 2026-08-24
           path: ./.github/actions/woo-product-deploy
           token: ${{ secrets.ORG_DEPLOY_SECRET }}
 


### PR DESCRIPTION
## Changes proposed in this pull request

The release workflow checks out `woocommerce/woo-product-deploy` and invokes it as a local composite action. Its previous commit contains five nested action references that use version tags, so enabling the WooCommerce organization full-SHA policy would block the release job.

Update both `woo-product-deploy` checkouts to merge commit `1f35b88631478d8f57aa454f81363bb7eed309d3` from [woocommerce/woo-product-deploy#5](https://github.com/woocommerce/woo-product-deploy/pull/5). Keeping the sparse tooling checkout and invoked action on the same commit avoids using different deployment-tool revisions within one release run.

The prior Action Scheduler ref predates several existing upstream commits, including the `wporg:release` simulation fix. The invoked action still runs only for a real release here, while this repository retains its explicit dry-run path. The security-relevant `action.yml` change pins its five remote dependencies without changing their versions.

## How to test

- Confirm both `woo-product-deploy` checkout refs resolve to the immutable merge commit from upstream PR #5.
- Confirm every remote action dependency reachable from that commit is pinned to a 40-character SHA.
- Parse `.github/workflows/release.yml` as YAML.
- Run `git diff --check`.

## Changelog

No changelog entry is needed because this changes release tooling only and does not alter the shipped Action Scheduler library.

*\*left by Biff (AI agent) on behalf of Darren*
